### PR TITLE
More changes to enable Shenango integration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 ## lib Homa ####################################################################
 add_library(Homa
     src/CodeLocation.cc
+    src/CHoma.cc
     src/Debug.cc
     src/Driver.cc
     src/Homa.cc
@@ -80,9 +81,12 @@ add_library(Homa
     src/Policy.cc
     src/Receiver.cc
     src/Sender.cc
+    src/Shenango.cc
+    src/SimpleMailboxDir.cc
     src/StringUtil.cc
     src/ThreadId.cc
     src/TransportImpl.cc
+    src/TransportPoller.cc
     src/Util.cc
 )
 add_library(Homa::Homa ALIAS Homa)

--- a/include/Homa/Bindings/CHoma.h
+++ b/include/Homa/Bindings/CHoma.h
@@ -1,0 +1,233 @@
+/* Copyright (c) 2020 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/**
+ * @file CHoma.h
+ *
+ * Contains C-bindings for the Homa Transport API.
+ */
+
+#pragma once
+
+#include "Homa/OutMessageStatus.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Define handle types for various Homa objects.
+ *
+ * A handle type is essentially a thin wrapper around an opaque pointer.
+ * Compared to generic pointers, using handle types in the C API enables
+ * some type safety.
+ */
+#define DEFINE_HOMA_OBJ_HANDLE(x) typedef struct { void *p; } homa_##x;
+
+DEFINE_HOMA_OBJ_HANDLE(driver)      /* Homa::Driver     */
+DEFINE_HOMA_OBJ_HANDLE(inmsg)       /* Homa::InMessage  */
+DEFINE_HOMA_OBJ_HANDLE(outmsg)      /* Homa::OutMessage */
+DEFINE_HOMA_OBJ_HANDLE(mailbox)     /* Homa::Mailbox    */
+DEFINE_HOMA_OBJ_HANDLE(mailbox_dir) /* Homa::MailboxDir */
+DEFINE_HOMA_OBJ_HANDLE(sk)          /* Homa::Socket     */
+DEFINE_HOMA_OBJ_HANDLE(trans)       /* Homa::Transport  */
+
+/* ============================ */
+/*     Homa::InMessage API      */
+/* ============================ */
+
+/**
+ * homa_inmsg_ack - C-binding for Homa::InMessage::acknowledge
+ */
+extern void homa_inmsg_ack(homa_inmsg in_msg);
+
+/**
+ * homa_inmsg_dropped - C-binding for Homa::InMessage::dropped
+ */
+extern bool homa_inmsg_dropped(homa_inmsg in_msg);
+
+/**
+ * homa_inmsg_fail - C-binding for Homa::InMessage::fail
+ */
+extern void homa_inmsg_fail(homa_inmsg in_msg);
+
+/**
+ * homa_inmsg_get - C-binding for Homa::InMessage::get
+ */
+extern size_t homa_inmsg_get(homa_inmsg in_msg, size_t ofs, void *dst,
+                             size_t len);
+
+/**
+ * homa_inmsg_src_addr - C-binding for Homa::InMessage::getSourceAddress
+ */
+extern void homa_inmsg_src_addr(homa_inmsg in_msg, uint32_t *ip,
+                                uint16_t *port);
+
+/**
+ * homa_inmsg_len - C-binding for Homa::InMessage::length
+ */
+extern size_t homa_inmsg_len(homa_inmsg in_msg);
+
+/**
+ * homa_inmsg_release - C-binding for Homa::InMessage::release
+ */
+extern void homa_inmsg_release(homa_inmsg in_msg);
+
+/**
+ * homa_inmsg_strip - C-binding for Homa::InMessage::strip
+ */
+extern void homa_inmsg_strip(homa_inmsg in_msg, size_t n);
+
+
+/* ============================ */
+/*     Homa::OutMessage API     */
+/* ============================ */
+
+/**
+ * homa_outmsg_append - C-binding for Homa::OutMessage::append
+ */
+extern void homa_outmsg_append(homa_outmsg out_msg, const void *buf,
+                               size_t len);
+
+/**
+ * homa_outmsg_cancel - C-binding for Homa::OutMessage::cancel
+ */
+extern void homa_outmsg_cancel(homa_outmsg out_msg);
+
+/**
+ * homa_outmsg_status - C-binding for Homa::OutMessage::getStatus
+ */
+extern int homa_outmsg_status(homa_outmsg out_msg);
+
+/**
+ * homa_outmsg_prepend - C-binding for Homa::OutMessage::prepend
+ */
+extern void homa_outmsg_prepend(homa_outmsg out_msg, const void *buf,
+                                size_t len);
+
+/**
+ * homa_outmsg_reserve - C-binding for Homa::OutMessage::reserve
+ */
+extern void homa_outmsg_reserve(homa_outmsg out_msg, size_t n);
+
+/**
+ * homa_outmsg_send - C-binding for Homa::OutMessage::send
+ */
+extern void homa_outmsg_send(homa_outmsg out_msg, uint32_t ip, uint16_t port);
+
+/**
+ * homa_outmsg_register_cb - C-binding for
+ * Homa::OutMessage::registerCallbackEndState
+ */
+extern void homa_outmsg_register_cb_end_state(homa_outmsg out_msg,
+                                              void (*cb) (void*),
+                                              void *data);
+
+/**
+ * homa_outmsg_release - C-binding for Homa::OutMessage::release
+ */
+extern void homa_outmsg_release(homa_outmsg out_msg);
+
+/* ============================ */
+/*       Homa::Socket API       */
+/* ============================ */
+
+/**
+ * homa_sk_alloc - C-binding for Homa::Socket::alloc
+ */
+extern homa_outmsg homa_sk_alloc(homa_sk sk);
+
+/**
+ * homa_sk_receive - C-binding for Homa::Socket::receive
+ */
+extern homa_inmsg homa_sk_receive(homa_sk sk, bool blocking);
+
+/**
+ * homa_sk_shutdown - C-binding for Homa::Socket::shutdown
+ */
+extern void homa_sk_shutdown(homa_sk sk);
+
+/**
+ * homa_sk_is_shutdown - C-binding for Homa::Socket::isShutdown
+ */
+extern bool homa_sk_is_shutdown(homa_sk sk);
+
+/**
+ * homa_sk_local_addr - C-binding for Homa::Socket::getLocalAddress
+ */
+extern void homa_sk_local_addr(homa_sk sk, uint32_t *ip, uint16_t *port);
+
+/**
+ * homa_sk_close - C-binding for Homa::Socket::close
+ */
+extern void homa_sk_close(homa_sk sk);
+
+/* ============================ */
+/*     Homa::Transport API      */
+/* ============================ */
+
+/**
+ * homa_trans_create - C-binding for Homa::Transport::create
+ */
+extern homa_trans homa_trans_create(homa_driver drv, homa_mailbox_dir dir,
+                                    uint64_t id);
+
+/**
+ * homa_trans_free - C-binding for Homa::Transport::free
+ */
+extern void homa_trans_free(homa_trans trans);
+
+/**
+ * homa_trans_open - C-binding for Homa::Transport::open
+ */
+extern homa_sk homa_trans_open(homa_trans trans, uint16_t port);
+
+/**
+ * homa_trans_check_timeouts - C-binding for Homa::Transport::checkTimeouts
+ */
+extern uint64_t homa_trans_check_timeouts(homa_trans trans);
+
+/**
+ * homa_trans_id - C-binding for Homa::Transport::getId
+ */
+extern uint64_t homa_trans_id(homa_trans trans);
+
+/**
+ * homa_trans_proc - C-binding for Homa::Transport::processPacket
+ */
+extern void homa_trans_proc(homa_trans trans, uintptr_t desc, void* payload,
+                            int32_t len, uint32_t src_ip);
+
+/**
+ * homa_trans_try_send - C-binding for
+ * Homa::Transport::registerCallbackSendReady
+ */
+extern void homa_trans_register_cb_send_ready(homa_trans trans,
+                                              void (*cb) (void*), void *data);
+
+/**
+ * homa_trans_try_send - C-binding for Homa::Transport::trySend
+ */
+extern bool homa_trans_try_send(homa_trans trans, uint64_t *wait_until);
+
+/**
+ * homa_trans_try_grant - C-binding for Homa::Transport::trySendGrants
+ */
+extern bool homa_trans_try_grant(homa_trans trans);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/Homa/Drivers/DPDK/DpdkDriver.h
+++ b/include/Homa/Drivers/DPDK/DpdkDriver.h
@@ -119,7 +119,7 @@ class DpdkDriver : public Driver {
     virtual ~DpdkDriver();
 
     /// See Driver::allocPacket()
-    virtual Packet* allocPacket();
+    virtual Packet allocPacket();
 
     /// See Driver::sendPacket()
     virtual void sendPacket(Packet* packet, IpAddress destination,
@@ -133,11 +133,11 @@ class DpdkDriver : public Driver {
 
     /// See Driver::receivePackets()
     virtual uint32_t receivePackets(uint32_t maxPackets,
-                                    Packet* receivedPackets[],
+                                    Packet receivedPackets[],
                                     IpAddress sourceAddresses[]);
 
     /// See Driver::releasePackets()
-    virtual void releasePackets(Packet* packets[], uint16_t numPackets);
+    virtual void releasePackets(Packet packets[], uint16_t numPackets);
 
     /// See Driver::getHighestPacketPriority()
     virtual int getHighestPacketPriority();

--- a/include/Homa/Drivers/Fake/FakeDriver.h
+++ b/include/Homa/Drivers/Fake/FakeDriver.h
@@ -52,11 +52,11 @@ void setPacketLossRate(double lossRate);
  * @sa Driver::Packet
  */
 struct FakePacket {
-    /// C-style "inheritance"; used to maintain the base struct as a POD type.
-    Driver::Packet base;
-
     /// Raw storage for this packets payload.
     char buf[MAX_PAYLOAD_SIZE];
+
+    /// Number of bytes in the payload.
+    int length;
 
     /// Source IpAddress of the packet.
     IpAddress sourceIp;
@@ -65,8 +65,8 @@ struct FakePacket {
      * FakePacket constructor.
      */
     explicit FakePacket()
-        : base{.payload = buf, .length = 0}
-        , buf()
+        : buf()
+        , length()
         , sourceIp()
     {}
 
@@ -74,11 +74,24 @@ struct FakePacket {
      * Copy constructor.
      */
     FakePacket(const FakePacket& other)
-        : base{.payload = buf, .length = other.base.length}
-        , buf()
+        : buf()
+        , length(other.length)
         , sourceIp()
     {
-        memcpy(base.payload, other.base.payload, MAX_PAYLOAD_SIZE);
+        memcpy(buf, other.buf, MAX_PAYLOAD_SIZE);
+    }
+
+    /**
+     * Convert this FakePacket to a generic Driver packet representation.
+     */
+    Driver::Packet toPacket()
+    {
+        Driver::Packet packet = {
+            .descriptor = (uintptr_t) this,
+            .payload = buf,
+            .length = length
+        };
+        return packet;
     }
 };
 
@@ -109,13 +122,13 @@ class FakeDriver : public Driver {
      */
     virtual ~FakeDriver();
 
-    virtual Packet* allocPacket();
+    virtual Packet allocPacket();
     virtual void sendPacket(Packet* packet, IpAddress destination,
                             int priority);
     virtual uint32_t receivePackets(uint32_t maxPackets,
-                                    Packet* receivedPackets[],
+                                    Packet receivedPackets[],
                                     IpAddress sourceAddresses[]);
-    virtual void releasePackets(Packet* packets[], uint16_t numPackets);
+    virtual void releasePackets(Packet packets[], uint16_t numPackets);
     virtual int getHighestPacketPriority();
     virtual uint32_t getMaxPayloadSize();
     virtual uint32_t getBandwidth();

--- a/include/Homa/Homa.h
+++ b/include/Homa/Homa.h
@@ -24,18 +24,27 @@
 #define HOMA_INCLUDE_HOMA_HOMA_H
 
 #include <Homa/Driver.h>
-
-#include <atomic>
-#include <bitset>
-#include <cstdint>
+#include <functional>
 
 namespace Homa {
 
 /**
  * Shorthand for an std::unique_ptr with a customized deleter.
+ *
+ * This is used to implement the "borrow" semantics for interface classes like
+ * InMessage, OutMessage, and Socket; that is, a user can obtain pointers to
+ * these objects and use them to make function calls, but the user must always
+ * return the objects back to the transport library eventually because the user
+ * has no idea how to destruct the objects or reclaim memory.
  */
 template <typename T>
 using unique_ptr = std::unique_ptr<T, typename T::Deleter>;
+
+/**
+ * Shorthand for user-defined callback functions which are used by the transport
+ * library to notify users of certain events.
+ */
+using Callback = std::function<void()>;
 
 /**
  * Represents a socket address to (from) which we can send (receive) messages.
@@ -104,6 +113,11 @@ class InMessage {
                        size_t count) const = 0;
 
     /**
+     * Return the remote address from which this Message is sent.
+     */
+    virtual SocketAddress getSourceAddress() const = 0;
+
+    /**
      * Return the number of bytes this Message contains.
      */
     virtual size_t length() const = 0;
@@ -117,6 +131,12 @@ class InMessage {
     virtual void strip(size_t count) = 0;
 
   protected:
+    /**
+     * Use protected destructor to prevent users from calling delete on pointers
+     * to this interface.
+     */
+    ~InMessage() = default;
+
     /**
      * Signal that this message is no longer needed.  The caller should not
      * access this message following this call.
@@ -134,14 +154,7 @@ class OutMessage {
     /**
      * Defines the possible states of an OutMessage.
      */
-    enum class Status {
-        NOT_STARTED,  //< The sending of this message has not started.
-        IN_PROGRESS,  //< The message is in the process of being sent.
-        CANCELED,     //< The message was canceled while still IN_PROGRESS.
-        SENT,         //< The message has been completely sent.
-        COMPLETED,    //< The message has been received and processed.
-        FAILED,       //< The message failed to be delivered and processed.
-    };
+    using Status = OutMessageStatus;
 
     /**
      * Options with which an OutMessage can be sent.
@@ -211,6 +224,15 @@ class OutMessage {
     virtual void prepend(const void* source, size_t count) = 0;
 
     /**
+     * Register a callback function to be invoked when the status of this
+     * message reaches an end state.
+     *
+     * @param func
+     *      The function object to invoke.
+     */
+    virtual void registerCallbackEndState(Callback func) = 0;
+
+    /**
      * Reserve a number of bytes at the beginning of the Message.
      *
      * The reserved space is used when bytes are prepended to the Message.
@@ -240,6 +262,12 @@ class OutMessage {
 
   protected:
     /**
+     * Use protected destructor to prevent users from calling delete on pointers
+     * to this interface.
+     */
+    ~OutMessage() = default;
+
+    /**
      * Signal that this message is no longer needed.  The caller should not
      * access this message following this call.
      */
@@ -247,58 +275,265 @@ class OutMessage {
 };
 
 /**
+ * Represents a location which can hold incoming messages temporarily before
+ * they are consumed by high-level applications.
+ *
+ * Despite a one-to-one relationship between Mailbox and Socket, this class
+ * is decoupled from Socket for three reasons:
+ * <ul>
+ * <li> Abstract out the interaction with the user's thread scheduler: e.g.,
+ * a user system may want to block on receive until a message is delivered;
+ * <li> Abstract out the mechanism for high-performance message dispatch: e.g.,
+ * a user system may choose to implement the message receive queue with a
+ * concurrent MPMC queue as opposed to a linked-list protected by a mutex;
+ * <li> Abstract out the mechanism for safe memory reclamation of the receive
+ * queue: e.g., RCU is a well-known solution, reference counting is another.
+ * </ul>
+ *
+ * Note: methods in this class are NOT meant to be called by user applications
+ * directly; instead, they are defined by user applications and called by the
+ * Homa transport library.
+ *
+ * This class is thread-safe.
+ *
+ * @sa MailboxDir
+ */
+class Mailbox {
+  public:
+    /**
+     * Destructor.
+     */
+    virtual ~Mailbox() = default;
+
+    /**
+     * Signal that the caller will not access the mailbox after this call.
+     * A mailbox will only be destroyed if it's removed from the directory
+     * and closed by all openers.
+     *
+     * Not meant to be called by users.
+     *
+     * @sa MailboxDir::open()
+     */
+    virtual void close() = 0;
+
+    /**
+     * Used by a transport to deliver an ingress message to this mailbox.
+     *
+     * Not meant to be called by users.
+     *
+     * @param message
+     *      An ingress message just completed by the transport.
+     */
+    virtual void deliver(InMessage* message) = 0;
+
+    /**
+     * Retrieve a message currently stored in the mailbox.
+     *
+     * Not meant to be called by users; use Socket::receive() instead.
+     *
+     * @param blocking
+     *      When set to true, this method should not return until a message
+     *      arrives or the corresponding socket is shut down.
+     * @return
+     *      A message previously delivered to this mailbox, if the mailbox is
+     *      not empty; nullptr, otherwise.
+     *
+     * @sa Socket::receive()
+     */
+    virtual InMessage* retrieve(bool blocking) = 0;
+
+    /**
+     * Invoked when the corresponding socket of the mailbox is shut down.
+     * All pending retrieve() requests must return immediately.
+     */
+    virtual void socketShutdown() = 0;
+};
+
+/**
+ * Provides a means to keep track of the mailboxes that are currently in use
+ * by Homa sockets.
+ *
+ * This class is separated out from Transport to allow users to 1) use their
+ * own data structures to store the map from port numbers to mailboxes, and
+ * 2) apply their own mechanisms to perform synchronization (e.g., hash map
+ * with fine-grained locks, RCU to delay mailbox destruction, etc).
+ *
+ * Similar to Mailbox, methods in this class are NOT meant to be called by
+ * user applications.
+ *
+ * This class is thread-safe.
+ */
+class MailboxDir {
+  public:
+    /**
+     * Destructor.
+     */
+    virtual ~MailboxDir() = default;
+
+    /**
+     * Allocate a new mailbox in the directory.
+     *
+     * @param port
+     *      Port number which identifies the mailbox.
+     * @return
+     *      Pointer to the new Mailbox on success; nullptr, if the port number
+     *      is already in use.
+     */
+    virtual Mailbox* alloc(uint16_t port) = 0;
+
+    /**
+     * Find and open the mailbox that matches the given port number.  Once a
+     * mailbox is opened, it's guaranteed to remain usable even if someone else
+     * removes it from the directory.
+     *
+     * @param port
+     *      Port number which identifies the mailbox.
+     * @return
+     *      Pointer to the opened mailbox on success; nullptr, if the desired
+     *      mailbox doesn't exist.
+     */
+    virtual Mailbox* open(uint16_t port) = 0;
+
+    /**
+     * Remove the mailbox that matches the given port number.
+     *
+     * @param port
+     *      Port number of the mailbox that will be removed.
+     * @return
+     *      True on success; false, if the desired mailbox doesn't exist.
+     */
+    virtual bool remove(uint16_t port) = 0;
+};
+
+/**
+ * Connection-less socket that can be used to send and receive Homa messages.
+ *
+ * This class is thread-safe.
+ */
+class Socket {
+  public:
+    using Address = SocketAddress;
+
+    /**
+     * Custom deleter for use with Homa::unique_ptr.
+     */
+    struct Deleter {
+        void operator()(Socket* socket)
+        {
+            socket->close();
+        }
+    };
+
+    /**
+     * Allocate Message that can be sent with this Socket.
+     *
+     * @param sourcePort
+     *      Port number of the socket from which the message will be sent.
+     * @return
+     *      A pointer to the allocated message or nullptr if the socket has
+     *      been shut down.
+     */
+    virtual Homa::unique_ptr<Homa::OutMessage> alloc() = 0;
+
+    /**
+     * Check for and return a Message sent to this Socket if available.
+     *
+     * @param blocking
+     *      When set to true, this method should not return until a message
+     *      arrives or the socket is shut down.
+     * @return
+     *      Pointer to the received message, if any.  Otherwise, nullptr is
+     *      returned if no message has been delivered or the socket has been
+     *      shut down.
+     */
+    virtual Homa::unique_ptr<Homa::InMessage> receive(bool blocking) = 0;
+
+    /**
+     * Disable the socket.  Once a socket is shut down, all ongoing/subsequent
+     * requests on the socket will return a failure.
+     *
+     * When multiple threads are working on a socket, this method can be used
+     * to notify other threads to drop their references to this socket so that
+     * the caller can safely close() the socket.
+     */
+    virtual void shutdown() = 0;
+
+    /**
+     * Check if the Socket has been shut down.
+     */
+    virtual bool isShutdown() const = 0;
+
+    /**
+     * Return the local IP address and port number of this Socket.
+     */
+    virtual Socket::Address getLocalAddress() const = 0;
+
+  protected:
+    /**
+     * Use protected destructor to prevent users from calling delete on pointers
+     * to this interface.
+     */
+    ~Socket() = default;
+
+    /**
+     * Signal that this Socket is no longer needed.  No one should access this
+     * socket after this call.
+     *
+     * Note: outgoing messages already allocated from this socket will not be
+     * affected.
+     */
+    virtual void close() = 0;
+};
+
+/**
  * Provides a means of communicating across the network using the Homa protocol.
  *
- * The transport is used to send and receive messages across the network using
- * the RemoteOp and ServerOp abstractions.  The execution of the transport is
- * driven through repeated calls to the Transport::poll() method; the transport
- * will not make any progress otherwise.
+ * The execution of the transport is driven through repeated calls to methods
+ * like checkTimeouts(), processPacket(), trySend(), and trySendGrants(); the
+ * transport will not make any progress otherwise.
  *
  * This class is thread-safe.
  */
 class Transport {
   public:
     /**
+     * Custom deleter for use with std::unique_ptr.
+     */
+    struct Deleter {
+        void operator()(Transport* transport)
+        {
+            transport->free();
+        }
+    };
+
+    /**
      * Return a new instance of a Homa-based transport.
-     *
-     * The caller is responsible for calling free() on the returned pointer.
      *
      * @param driver
      *      Driver with which this transport should send and receive packets.
+     * @param mailboxDir
+     *      Mailbox directory with which this transport should decide where
+     *      to deliver a message.
      * @param transportId
      *      This transport's unique identifier in the group of transports among
      *      which this transport will communicate.
      * @return
      *      Pointer to the new transport instance.
      */
-    static Transport* create(Driver* driver, uint64_t transportId);
+    static Homa::unique_ptr<Transport> create(Driver* driver,
+                                              MailboxDir* mailboxDir,
+                                              uint64_t transportId);
 
     /**
-     * Allocate Message that can be sent with this Transport.
+     * Create a socket that can be used to send and receive messages.
      *
-     * @param sourcePort
-     *      Port number of the socket from which the message will be sent.
+     * @param port
+     *      The port number allocated to the socket.
      * @return
-     *      A pointer to the allocated message.
+     *      Pointer to the new socket, if the port number is not in use;
+     *      nullptr, otherwise.
      */
-    virtual Homa::unique_ptr<Homa::OutMessage> alloc(uint16_t sourcePort) = 0;
-
-    /**
-     * Check for and return a Message sent to this Transport if available.
-     *
-     * @return
-     *      Pointer to the received message, if any.  Otherwise, nullptr is
-     *      returned if no message has been delivered.
-     */
-    virtual Homa::unique_ptr<Homa::InMessage> receive() = 0;
-
-    /**
-     * Make incremental progress performing all Transport functionality.
-     *
-     * This method MUST be called for the Transport to make progress and should
-     * be called frequently to ensure timely progress.
-     */
-    virtual void poll() = 0;
+    virtual Homa::unique_ptr<Socket> open(uint16_t port) = 0;
 
     /**
      * Return the driver that this transport uses to send and receive packets.
@@ -309,6 +544,85 @@ class Transport {
      * Return this transport's unique identifier.
      */
     virtual uint64_t getId() = 0;
+
+    /**
+     * Process any timeouts that have expired.
+     *
+     * This method must be called periodically to ensure timely handling of
+     * expired timeouts.
+     *
+     * @return
+     *      The rdtsc cycle time when this method should be called again.
+     */
+    virtual uint64_t checkTimeouts() = 0;
+
+    /**
+     * Handle an ingress packet by running it through the transport protocol
+     * stack.
+     *
+     * @param packet
+     *      The ingress packet.
+     * @param source
+     *      IpAddress of the socket from which the packet is sent.
+     */
+    virtual void processPacket(Driver::Packet* packet, IpAddress source) = 0;
+
+    /**
+     * Register a callback function to be invoked when some packets just became
+     * ready to be sent (and there was none before).
+     *
+     * This callback allows the transport library to notify the users that
+     * trySend() should be invoked again as soon as possible. For example,
+     * the callback can be used to implement wakeup signals for the thread
+     * that is responsible for calling trySend(), if this thread decides to
+     * sleep when there is no packets to send.
+     *
+     * @param func
+     *      The function object to invoke.
+     */
+    virtual void registerCallbackSendReady(Callback func) = 0;
+
+    /**
+     * Attempt to send out packets for any messages with unscheduled/granted
+     * bytes in a way that limits queue buildup in the NIC.
+     *
+     * This method must be called eagerly to allow the Transport to make
+     * progress toward sending outgoing messages.
+     *
+     * @param[out] waitUntil
+     *      The rdtsc cycle time when this method should be called again
+     *      (this allows the NIC to drain its transmit queue). Only set
+     *      when this method returns true.
+     * @return
+     *      True if more packets are ready to be transmitted when the method
+     *      returns; false, otherwise.
+     */
+    virtual bool trySend(uint64_t* waitUntil) = 0;
+
+    /**
+     * Attempt to grant to incoming messages according to the Homa protocol.
+     *
+     * This method must be called eagerly to allow the Transport to make
+     * progress toward receiving incoming messages.
+     *
+     * @return
+     *      True if the method has found some messages to grant; false,
+     *      otherwise.
+     */
+    virtual bool trySendGrants() = 0;
+
+  protected:
+    /**
+     * Use protected destructor to prevent users from calling delete on pointers
+     * to this interface.
+     */
+    ~Transport() = default;
+
+    /**
+     * Free this transport instance.  No one should not access this transport
+     * following this call.
+     */
+    virtual void free() = 0;
 };
 
 /**

--- a/include/Homa/OutMessageStatus.h
+++ b/include/Homa/OutMessageStatus.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2020 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+/**
+ * Defines the possible states of an OutMessage.
+ */
+#ifdef __cplusplus
+enum class OutMessageStatus : int {
+#else
+enum homa_outmsg_status {
+#endif
+    NOT_STARTED,  //< The sending of this message has not started.
+    IN_PROGRESS,  //< The message is in the process of being sent.
+    CANCELED,     //< The message was canceled while still IN_PROGRESS.
+    SENT,         //< The message has been completely sent.
+    COMPLETED,    //< The message has been received and processed.
+    FAILED,       //< The message failed to be delivered and processed.
+};

--- a/include/Homa/Shenango.h
+++ b/include/Homa/Shenango.h
@@ -1,0 +1,77 @@
+/* Copyright (c) 2020 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/**
+ * @file Shenango.h
+ *
+ * Contains the glue code for Homa-Shenango integration. This is the only
+ * header Shenango needs to include in order to use Homa transport.
+ *
+ * Shenango is an experimental operating system that aims to provide low tail
+ * latency and high CPU efficiency simultaneously for servers in datacenters.
+ * See <https://github.com/shenango/shenango> for more information.
+ *
+ * This file follows the Shenango coding style.
+ */
+
+#pragma once
+
+#include "Bindings/CHoma.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * homa_driver_create - creates a shim driver that translates Homa::Driver
+ * operations to Shenango functions
+ * @proto: protocol number reserved for Homa transport protocol
+ * @local_ip: local IP address of the driver
+ * @max_payload: maximum number of bytes carried by the packet payload
+ * @link_speed: effective network bandwidth, in Mbits/second
+ *
+ * Returns a handle to the driver created.
+ */
+extern homa_driver homa_driver_create(uint8_t proto, uint32_t local_ip,
+        uint32_t max_payload, uint32_t link_speed);
+
+/**
+ * homa_driver_free - frees a shim driver created earlier with
+ * @homa_driver_create.
+ * @param drv: the driver to free
+ */
+extern void homa_driver_free(homa_driver drv);
+
+/**
+ * homa_mb_dir_create - creates a shim mailbox directory that translates
+ * Homa::Mailbox operations to Shenango functions
+ * @proto: protocol number reserved for Homa transport protocol
+ * @local_ip: local IP address of the driver
+ *
+ * Returns a handle to the mailbox created.
+ */
+extern homa_mailbox_dir homa_mb_dir_create(uint8_t proto, uint32_t local_ip);
+
+/**
+ * homa_mb_dir_free - frees a shim mailbox directory created earlier with
+ * @homa_mb_dir_create.
+ * @param mailbox_dir: the mailbox directory to free
+ */
+extern void homa_mb_dir_free(homa_mailbox_dir mailbox_dir);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/Homa/Util.h
+++ b/include/Homa/Util.h
@@ -21,14 +21,6 @@
 #include <cstdio>
 #include <string>
 
-/// Cast a member of a structure out to the containing structure.
-template <class P, class M>
-P*
-container_of(M* ptr, const M P::*member)
-{
-    return (P*)((char*)ptr - (size_t) & (reinterpret_cast<P*>(0)->*member));
-}
-
 namespace Homa {
 namespace Util {
 

--- a/include/Homa/Utils/SimpleMailboxDir.h
+++ b/include/Homa/Utils/SimpleMailboxDir.h
@@ -1,0 +1,62 @@
+/* Copyright (c) 2020, Stanford University
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/**
+ * @file Homa/Utils/SimpleMailboxDir.h
+ *
+ * Contains a simple reference implementation for the pluggable mailbox
+ * directory in the Homa transport library. A mailbox directory is essential
+ * to get a working transport but it's not central to the Homa protocol.
+ *
+ * Users may choose to use this reference implementation for starter, or define
+ * their own implementation for best performance.
+ */
+
+#pragma once
+
+#include <Homa/Homa.h>
+#include <unordered_map>
+
+namespace Homa {
+
+/// Forward declaration
+class SpinLock;
+class MailboxImpl;
+
+/**
+ * A simple reference implementation of Homa::MailboxDir.
+ *
+ * This class relies on a monitor-style lock to protect the hash table that
+ * maps port numbers to mailboxes and uses reference-counting for safe
+ * reclamation of removed mailboxes.
+ */
+class SimpleMailboxDir final : public MailboxDir {
+  public:
+    explicit SimpleMailboxDir();
+    ~SimpleMailboxDir() override;
+    Mailbox* alloc(uint16_t port) override;
+    Mailbox* open(uint16_t port) override;
+    bool remove(uint16_t port) override;
+
+  private:
+    /// Monitor-style lock.
+    std::unique_ptr<SpinLock> mutex;
+
+    /// Hash table that maps port numbers to mailboxes.
+    std::unordered_map<uint16_t, MailboxImpl*> map;
+};
+
+
+}  // namespace Homa

--- a/include/Homa/Utils/TransportPoller.h
+++ b/include/Homa/Utils/TransportPoller.h
@@ -1,0 +1,55 @@
+/* Copyright (c) 2020, Stanford University
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <atomic>
+
+namespace Homa {
+
+/// Forward declaration.
+class Transport;
+
+/**
+ * Provides a means to drive the execution of a transport through repeated
+ * calls to the poll() method.
+ *
+ * This class demonstrates a simple way to invoke the Homa::Transport APIs
+ * in a poll-based programming style. In practice, users will often need to
+ * invoke the Transport APIs in ways that fit their systems better. The Homa-
+ * Shenango integration provides a concrete example.
+ *
+ * This class is thread-safe; although calling poll() from multiple threads
+ * provides no performance benefit.
+ *
+ * @sa Homa/Shenango.h
+ */
+class TransportPoller {
+  public:
+    explicit TransportPoller(Transport* transport);
+    ~TransportPoller() = default;
+    void poll();
+
+  private:
+    void processPackets();
+
+    /// Transport instance whose execution is driven by this poller.
+    Transport* const transport;
+
+    /// Caches the next cycle time that timeouts will need to rechecked.
+    std::atomic<uint64_t> nextTimeoutCycles;
+};
+
+}  // namespace Homa

--- a/src/CHoma.cc
+++ b/src/CHoma.cc
@@ -1,0 +1,200 @@
+/* Copyright (c) 2020, Stanford University
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "Homa/Homa.h"
+#include "Homa/Bindings/CHoma.h"
+
+using namespace Homa;
+
+/// Shorthand for converting C-style Homa object handle types back to C++ types.
+#define deref(T, x) (*static_cast<T*>(x.p))
+
+void homa_inmsg_ack(homa_inmsg in_msg)
+{
+    deref(InMessage, in_msg).acknowledge();
+}
+
+bool homa_inmsg_dropped(homa_inmsg in_msg)
+{
+    return deref(InMessage, in_msg).dropped();
+}
+
+void homa_inmsg_fail(homa_inmsg in_msg)
+{
+    deref(InMessage, in_msg).fail();
+}
+
+size_t homa_inmsg_get(homa_inmsg in_msg, size_t ofs, void* dst, size_t len)
+{
+    return deref(InMessage, in_msg).get(ofs, dst, len);
+}
+
+void homa_inmsg_src_addr(homa_inmsg in_msg, uint32_t *ip, uint16_t *port)
+{
+    SocketAddress src = deref(InMessage, in_msg).getSourceAddress();
+    *ip = (uint32_t)src.ip;
+    *port = src.port;
+}
+
+size_t homa_inmsg_len(homa_inmsg in_msg)
+{
+    return deref(InMessage, in_msg).length();
+}
+
+void homa_inmsg_release(homa_inmsg in_msg)
+{
+    InMessage::Deleter deleter;
+    deleter(&deref(InMessage, in_msg));
+}
+
+void homa_inmsg_strip(homa_inmsg in_msg, size_t n)
+{
+    deref(InMessage, in_msg).strip(n);
+}
+
+void homa_outmsg_append(homa_outmsg out_msg, const void* buf, size_t len)
+{
+    deref(OutMessage, out_msg).append(buf, len);
+}
+
+void homa_outmsg_cancel(homa_outmsg out_msg)
+{
+    deref(OutMessage, out_msg).cancel();
+}
+
+int homa_outmsg_status(homa_outmsg out_msg)
+{
+    return int(deref(OutMessage, out_msg).getStatus());
+}
+
+void homa_outmsg_prepend(homa_outmsg out_msg, const void* buf, size_t len)
+{
+    deref(OutMessage, out_msg).prepend(buf, len);
+}
+
+void homa_outmsg_reserve(homa_outmsg out_msg, size_t n)
+{
+    deref(OutMessage, out_msg).reserve(n);
+}
+
+void homa_outmsg_send(homa_outmsg out_msg, uint32_t ip, uint16_t port)
+{
+    deref(OutMessage, out_msg).send({IpAddress{ip}, port});
+}
+
+void homa_outmsg_register_cb_end_state(homa_outmsg out_msg,
+                                       void (*cb) (void*), void *data)
+{
+    std::function<void()> func = std::bind(cb, data);
+    deref(OutMessage, out_msg).registerCallbackEndState(func);
+}
+
+void homa_outmsg_release(homa_outmsg out_msg)
+{
+    OutMessage::Deleter deleter;
+    deleter(&deref(OutMessage, out_msg));
+}
+
+homa_outmsg homa_sk_alloc(homa_sk sk)
+{
+    unique_ptr<OutMessage> out_msg = deref(Socket, sk).alloc();
+    return homa_outmsg{out_msg.release()};
+}
+
+homa_inmsg homa_sk_receive(homa_sk sk, bool blocking)
+{
+    unique_ptr<InMessage> in_msg = deref(Socket, sk).receive(blocking);
+    return homa_inmsg{in_msg.release()};
+}
+
+void homa_sk_shutdown(homa_sk sk)
+{
+    deref(Socket, sk).shutdown();
+}
+
+bool homa_sk_is_shutdown(homa_sk sk)
+{
+    return deref(Socket, sk).isShutdown();
+}
+
+void homa_sk_local_addr(homa_sk sk, uint32_t *ip, uint16_t *port)
+{
+    SocketAddress addr = deref(Socket, sk).getLocalAddress();
+    *ip = (uint32_t)addr.ip;
+    *port = addr.port;
+}
+
+void homa_sk_close(homa_sk sk)
+{
+    Socket::Deleter deleter;
+    deleter(&deref(Socket, sk));
+}
+
+homa_trans homa_trans_create(homa_driver drv, homa_mailbox_dir dir, uint64_t id)
+{
+    unique_ptr<Transport> trans =
+        Transport::create(&deref(Driver, drv), &deref(MailboxDir, dir), id);
+    return homa_trans{trans.release()};
+}
+
+void homa_trans_free(homa_trans trans)
+{
+    Transport::Deleter deleter;
+    deleter(&deref(Transport, trans));
+}
+
+homa_sk homa_trans_open(homa_trans trans, uint16_t port)
+{
+    unique_ptr<Socket> sk = deref(Transport, trans).open(port);
+    return homa_sk{sk.release()};
+}
+
+uint64_t homa_trans_check_timeouts(homa_trans trans)
+{
+    return deref(Transport, trans).checkTimeouts();
+}
+
+uint64_t homa_trans_id(homa_trans trans)
+{
+    return deref(Transport, trans).getId();
+}
+
+void homa_trans_proc(homa_trans trans, uintptr_t desc, void* payload,
+                     int32_t len, uint32_t src_ip)
+{
+    Driver::Packet packet = {
+        .descriptor = desc,
+        .payload = payload,
+        .length = len
+    };
+    deref(Transport, trans).processPacket(&packet, IpAddress{src_ip});
+}
+
+void homa_trans_register_cb_send_ready(homa_trans trans, void (*cb) (void*),
+                                       void *data)
+{
+    std::function<void()> func = std::bind(cb, data);
+    deref(Transport, trans).registerCallbackSendReady(func);
+}
+
+bool homa_trans_try_send(homa_trans trans, uint64_t *wait_until)
+{
+    return deref(Transport, trans).trySend(wait_until);
+}
+
+bool homa_trans_try_grant(homa_trans trans)
+{
+    return deref(Transport, trans).trySendGrants();
+}

--- a/src/ControlPacket.h
+++ b/src/ControlPacket.h
@@ -39,11 +39,11 @@ template <typename PacketHeaderType, typename... Args>
 void
 send(Driver* driver, IpAddress address, Args&&... args)
 {
-    Driver::Packet* packet = driver->allocPacket();
-    new (packet->payload) PacketHeaderType(static_cast<Args&&>(args)...);
-    packet->length = sizeof(PacketHeaderType);
-    Perf::counters.tx_bytes.add(packet->length);
-    driver->sendPacket(packet, address, driver->getHighestPacketPriority());
+    Driver::Packet packet = driver->allocPacket();
+    new (packet.payload) PacketHeaderType(static_cast<Args&&>(args)...);
+    packet.length = sizeof(PacketHeaderType);
+    Perf::counters.tx_bytes.add(packet.length);
+    driver->sendPacket(&packet, address, driver->getHighestPacketPriority());
     driver->releasePackets(&packet, 1);
 }
 

--- a/src/Drivers/DPDK/DpdkDriver.cc
+++ b/src/Drivers/DPDK/DpdkDriver.cc
@@ -38,7 +38,7 @@ DpdkDriver::DpdkDriver(const char* ifname, NoEalInit _,
 DpdkDriver::~DpdkDriver() = default;
 
 /// See Driver::allocPacket()
-Driver::Packet*
+Driver::Packet
 DpdkDriver::allocPacket()
 {
     return pImpl->allocPacket();
@@ -67,14 +67,14 @@ DpdkDriver::uncork()
 
 /// See Driver::receivePackets()
 uint32_t
-DpdkDriver::receivePackets(uint32_t maxPackets, Packet* receivedPackets[],
+DpdkDriver::receivePackets(uint32_t maxPackets, Packet receivedPackets[],
                            IpAddress sourceAddresses[])
 {
     return pImpl->receivePackets(maxPackets, receivedPackets, sourceAddresses);
 }
 /// See Driver::releasePackets()
 void
-DpdkDriver::releasePackets(Packet* packets[], uint16_t numPackets)
+DpdkDriver::releasePackets(Packet packets[], uint16_t numPackets)
 {
     pImpl->releasePackets(packets, numPackets);
 }

--- a/src/Drivers/Fake/FakeDriverTest.cc
+++ b/src/Drivers/Fake/FakeDriverTest.cc
@@ -35,10 +35,9 @@ TEST(FakeDriverTest, constructor)
 
 TEST(FakeDriverTest, allocPacket)
 {
-    FakeDriver driver;
-    Driver::Packet* packet = driver.allocPacket();
     // allocPacket doesn't do much so we just need to make sure we can call it.
-    delete container_of(packet, &FakePacket::base);
+    FakeDriver driver;
+    Driver::Packet packet = driver.allocPacket();
 }
 
 TEST(FakeDriverTest, sendPackets)
@@ -46,7 +45,7 @@ TEST(FakeDriverTest, sendPackets)
     FakeDriver driver1;
     FakeDriver driver2;
 
-    Driver::Packet* packets[4];
+    Driver::Packet packets[4];
     IpAddress destinations[4];
     int prio[4];
     for (int i = 0; i < 4; ++i) {
@@ -65,7 +64,7 @@ TEST(FakeDriverTest, sendPackets)
     EXPECT_EQ(0U, driver2.nic.priorityQueue.at(6).size());
     EXPECT_EQ(0U, driver2.nic.priorityQueue.at(7).size());
 
-    driver1.sendPacket(packets[0], destinations[0], prio[0]);
+    driver1.sendPacket(&packets[0], destinations[0], prio[0]);
 
     EXPECT_EQ(1U, driver2.nic.priorityQueue.at(0).size());
     EXPECT_EQ(0U, driver2.nic.priorityQueue.at(1).size());
@@ -81,7 +80,7 @@ TEST(FakeDriverTest, sendPackets)
     }
 
     for (int i = 0; i < 4; ++i) {
-        driver1.sendPacket(packets[i], destinations[i], prio[i]);
+        driver1.sendPacket(&packets[i], destinations[i], prio[i]);
     }
 
     EXPECT_EQ(2U, driver2.nic.priorityQueue.at(0).size());
@@ -92,8 +91,6 @@ TEST(FakeDriverTest, sendPackets)
     EXPECT_EQ(0U, driver2.nic.priorityQueue.at(5).size());
     EXPECT_EQ(0U, driver2.nic.priorityQueue.at(6).size());
     EXPECT_EQ(0U, driver2.nic.priorityQueue.at(7).size());
-
-    delete container_of(packets[2], &FakePacket::base);
 }
 
 TEST(FakeDriverTest, receivePackets)
@@ -101,7 +98,7 @@ TEST(FakeDriverTest, receivePackets)
     std::string addressStr("42");
     FakeDriver driver;
 
-    Driver::Packet* packets[4];
+    Driver::Packet packets[4];
     IpAddress srcAddrs[4];
 
     // 3 packets at priority 7

--- a/src/Homa.cc
+++ b/src/Homa.cc
@@ -19,10 +19,13 @@
 
 namespace Homa {
 
-Transport*
-Transport::create(Driver* driver, uint64_t transportId)
+Homa::unique_ptr<Transport>
+Transport::create(Driver* driver, MailboxDir* mailboxDir,
+                  uint64_t transportId)
 {
-    return new Core::TransportImpl(driver, transportId);
+    Transport* transport =
+        new Core::TransportImpl(driver, mailboxDir, transportId);
+    return Homa::unique_ptr<Transport>(transport);
 }
 
 }  // namespace Homa

--- a/src/Mock/MockDriver.h
+++ b/src/Mock/MockDriver.h
@@ -31,22 +31,37 @@ namespace Mock {
 class MockDriver : public Driver {
   public:
     /**
-     * Used in unit tests to mock calls to Driver::Packet.
-     *
-     * @sa Driver::Packet.
+     * Used in unit tests to mock driver-specific packet buffers.
      */
-    using MockPacket = Driver::Packet;
+    struct PacketBuf {
+        /// External buffer which stores the packet data.
+        void* buffer;
 
-    MOCK_METHOD(Packet*, allocPacket, (), (override));
+        /**
+         * Convert this packet buffer to the generic Driver::Packet
+         * representation.
+         */
+        Driver::Packet toPacket(int length = 0)
+        {
+            Driver::Packet packet = {
+                .descriptor = (uintptr_t) this,
+                .payload = buffer,
+                .length = length
+            };
+            return packet;
+        }
+    };
+
+    MOCK_METHOD(Packet, allocPacket, (), (override));
     MOCK_METHOD(void, sendPacket,
                 (Packet * packet, IpAddress destination, int priority),
                 (override));
     MOCK_METHOD(void, flushPackets, ());
     MOCK_METHOD(uint32_t, receivePackets,
-                (uint32_t maxPackets, Packet* receivedPackets[],
+                (uint32_t maxPackets, Packet receivedPackets[],
                  IpAddress sourceAddresses[]),
                 (override));
-    MOCK_METHOD(void, releasePackets, (Packet * packets[], uint16_t numPackets),
+    MOCK_METHOD(void, releasePackets, (Packet packets[], uint16_t numPackets),
                 (override));
     MOCK_METHOD(int, getHighestPacketPriority, (), (override));
     MOCK_METHOD(uint32_t, getMaxPayloadSize, (), (override));

--- a/src/Mock/MockReceiver.h
+++ b/src/Mock/MockReceiver.h
@@ -33,7 +33,8 @@ class MockReceiver : public Core::Receiver {
   public:
     MockReceiver(Driver* driver, uint64_t messageTimeoutCycles,
                  uint64_t resendIntervalCycles)
-        : Receiver(driver, nullptr, messageTimeoutCycles, resendIntervalCycles)
+        : Receiver(driver, nullptr, nullptr, messageTimeoutCycles,
+                   resendIntervalCycles)
     {}
 
     MOCK_METHOD(void, handleDataPacket,
@@ -41,9 +42,8 @@ class MockReceiver : public Core::Receiver {
     MOCK_METHOD(void, handleBusyPacket, (Driver::Packet * packet), (override));
     MOCK_METHOD(void, handlePingPacket,
                 (Driver::Packet * packet, IpAddress sourceIp), (override));
-    MOCK_METHOD(Homa::InMessage*, receiveMessage, (), (override));
-    MOCK_METHOD(void, poll, (), (override));
     MOCK_METHOD(uint64_t, checkTimeouts, (), (override));
+    MOCK_METHOD(bool, trySendGrants, (), (override));
 };
 
 }  // namespace Mock

--- a/src/Mock/MockSender.h
+++ b/src/Mock/MockSender.h
@@ -45,8 +45,8 @@ class MockSender : public Core::Sender {
     MOCK_METHOD(void, handleUnknownPacket, (Driver::Packet * packet),
                 (override));
     MOCK_METHOD(void, handleErrorPacket, (Driver::Packet * packet), (override));
-    MOCK_METHOD(void, poll, (), (override));
     MOCK_METHOD(uint64_t, checkTimeouts, (), (override));
+    MOCK_METHOD(bool, trySend, (uint64_t*), (override));
 };
 
 }  // namespace Mock

--- a/src/SenderTest.cc
+++ b/src/SenderTest.cc
@@ -29,18 +29,26 @@ using ::testing::_;
 using ::testing::Eq;
 using ::testing::Mock;
 using ::testing::NiceMock;
-using ::testing::Pointee;
 using ::testing::Return;
+
+/**
+ * Defines a matcher EqPacket(p) to match two Driver::Packet* by their
+ * underlying packet buffer descriptors.
+ */
+MATCHER_P(EqPacket, p, "") { return arg->descriptor == p->descriptor; }
 
 class SenderTest : public ::testing::Test {
   public:
     SenderTest()
         : mockDriver()
-        , mockPacket{&payload}
+        , mockPacket()
         , mockPolicyManager(&mockDriver)
+        , payload()
+        , packetBuf {&payload}
         , sender()
         , savedLogPolicy(Debug::getLogPolicy())
     {
+        mockPacket = packetBuf.toPacket();
         ON_CALL(mockDriver, getBandwidth).WillByDefault(Return(8000));
         ON_CALL(mockDriver, getMaxPayloadSize).WillByDefault(Return(1031));
         ON_CALL(mockDriver, getQueuedBytes).WillByDefault(Return(0));
@@ -59,9 +67,10 @@ class SenderTest : public ::testing::Test {
     }
 
     NiceMock<Homa::Mock::MockDriver> mockDriver;
-    Homa::Mock::MockDriver::MockPacket mockPacket;
+    Driver::Packet mockPacket;
     NiceMock<Homa::Mock::MockPolicyManager> mockPolicyManager;
     char payload[1028];
+    Homa::Mock::MockDriver::PacketBuf packetBuf;
     Sender* sender;
     std::vector<std::pair<std::string, std::string>> savedLogPolicy;
 
@@ -96,7 +105,7 @@ class SenderTest : public ::testing::Test {
     }
 
     static bool setMessagePacket(Sender::Message* message, int index,
-                                 Driver::Packet* packet)
+                                 Driver::Packet packet)
     {
         if (message->occupied.test(index)) {
             return false;
@@ -139,7 +148,7 @@ TEST_F(SenderTest, handleDonePacket_basic)
         static_cast<Protocol::Packet::DoneHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(2);
 
     // No message.
@@ -170,7 +179,7 @@ TEST_F(SenderTest, handleDonePacket_CANCELED)
         static_cast<Protocol::Packet::DoneHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleDonePacket(&mockPacket);
@@ -188,7 +197,7 @@ TEST_F(SenderTest, handleDonePacket_COMPLETED)
         static_cast<Protocol::Packet::DoneHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -219,7 +228,7 @@ TEST_F(SenderTest, handleDonePacket_FAILED)
         static_cast<Protocol::Packet::DoneHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -252,7 +261,7 @@ TEST_F(SenderTest, handleDonePacket_IN_PROGRESS)
         static_cast<Protocol::Packet::DoneHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -285,7 +294,7 @@ TEST_F(SenderTest, handleDonePacket_NO_STARTED)
         static_cast<Protocol::Packet::DoneHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -311,10 +320,11 @@ TEST_F(SenderTest, handleResendPacket_basic)
     Protocol::MessageId id = {42, 1};
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
-    std::vector<Homa::Mock::MockDriver::MockPacket*> packets;
+    std::vector<Driver::Packet> packets;
     std::vector<int> priorities;
     for (int i = 0; i < 10; ++i) {
-        packets.push_back(new Homa::Mock::MockDriver::MockPacket{payload});
+        auto* packetBuf = new Homa::Mock::MockDriver::PacketBuf{payload};
+        packets.push_back(packetBuf->toPacket());
         priorities.push_back(0);
         setMessagePacket(message, i, packets[i]);
     }
@@ -333,14 +343,13 @@ TEST_F(SenderTest, handleResendPacket_basic)
     resendHdr->priority = 4;
 
     EXPECT_CALL(mockPolicyManager, getResendPriority).WillOnce(Return(7));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packets[3]), _, _))
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packets[3]), _, _))
         .WillOnce(
             [&priorities](auto _1, auto _2, int p) { priorities[3] = p; });
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packets[4]), _, _))
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packets[4]), _, _))
         .WillOnce(
             [&priorities](auto _1, auto _2, int p) { priorities[4] = p; });
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
-        .Times(1);
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1))).Times(1);
 
     sender->handleResendPacket(&mockPacket);
 
@@ -353,10 +362,11 @@ TEST_F(SenderTest, handleResendPacket_basic)
     EXPECT_EQ(7, priorities[3]);
     EXPECT_EQ(7, priorities[4]);
     EXPECT_EQ(0, priorities[5]);
-    EXPECT_TRUE(sender->sendReady.load());
+    EXPECT_TRUE(sender->sendReady);
 
     for (int i = 0; i < 10; ++i) {
-        delete packets[i];
+        uintptr_t packetBuf = packets[i].descriptor;
+        delete (Homa::Mock::MockDriver::PacketBuf*) packetBuf;
     }
 }
 
@@ -369,7 +379,7 @@ TEST_F(SenderTest, handleResendPacket_staleResend)
     resendHdr->index = 3;
     resendHdr->num = 5;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleResendPacket(&mockPacket);
@@ -382,8 +392,9 @@ TEST_F(SenderTest, handleResendPacket_badRequest_singlePacketMessage)
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
     SenderTest::addMessage(sender, id, message);
-    Homa::Mock::MockDriver::MockPacket* packet =
-        new Homa::Mock::MockDriver::MockPacket{payload};
+    Homa::Mock::MockDriver::PacketBuf* packetBuf =
+        new Homa::Mock::MockDriver::PacketBuf{payload};
+    Driver::Packet packet = packetBuf->toPacket();
     setMessagePacket(message, 0, packet);
 
     Protocol::Packet::ResendHeader* resendHdr =
@@ -393,7 +404,7 @@ TEST_F(SenderTest, handleResendPacket_badRequest_singlePacketMessage)
     resendHdr->num = 5;
     resendHdr->priority = 4;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -413,7 +424,7 @@ TEST_F(SenderTest, handleResendPacket_badRequest_singlePacketMessage)
 
     Debug::setLogHandler(std::function<void(Debug::DebugMessage)>());
 
-    delete packet;
+    delete packetBuf;
 }
 
 TEST_F(SenderTest, handleResendPacket_badRequest_outOfRange)
@@ -421,9 +432,10 @@ TEST_F(SenderTest, handleResendPacket_badRequest_outOfRange)
     Protocol::MessageId id = {42, 1};
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
-    std::vector<Homa::Mock::MockDriver::MockPacket*> packets;
+    std::vector<Driver::Packet> packets;
     for (int i = 0; i < 10; ++i) {
-        packets.push_back(new Homa::Mock::MockDriver::MockPacket{payload});
+        auto* packetBuf = new Homa::Mock::MockDriver::PacketBuf{payload};
+        packets.push_back(packetBuf->toPacket());
         setMessagePacket(message, i, packets[i]);
     }
     SenderTest::addMessage(sender, id, message, true, 5);
@@ -440,7 +452,7 @@ TEST_F(SenderTest, handleResendPacket_badRequest_outOfRange)
     resendHdr->num = 5;
     resendHdr->priority = 4;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -462,7 +474,8 @@ TEST_F(SenderTest, handleResendPacket_badRequest_outOfRange)
     Debug::setLogHandler(std::function<void(Debug::DebugMessage)>());
 
     for (int i = 0; i < 10; ++i) {
-        delete packets[i];
+        uintptr_t packetBuf = packets[i].descriptor;
+        delete (Homa::Mock::MockDriver::PacketBuf*) packetBuf;
     }
 }
 
@@ -472,9 +485,10 @@ TEST_F(SenderTest, handleResendPacket_eagerResend)
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
     char data[1028];
-    Homa::Mock::MockDriver::MockPacket dataPacket{data};
+    Homa::Mock::MockDriver::PacketBuf dataPacketBuf{data};
+    Driver::Packet dataPacket = dataPacketBuf.toPacket();
     for (int i = 0; i < 10; ++i) {
-        setMessagePacket(message, i, &dataPacket);
+        setMessagePacket(message, i, dataPacket);
     }
     SenderTest::addMessage(sender, id, message, true, 5);
     Sender::QueuedMessageInfo* info = &message->queuedMessageInfo;
@@ -490,15 +504,16 @@ TEST_F(SenderTest, handleResendPacket_eagerResend)
 
     // Expect the BUSY control packet.
     char busy[1028];
-    Homa::Mock::MockDriver::MockPacket busyPacket{busy};
-    EXPECT_CALL(mockDriver, allocPacket()).WillOnce(Return(&busyPacket));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(&busyPacket), _, _)).Times(1);
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&busyPacket), Eq(1)))
+    Homa::Mock::MockDriver::PacketBuf busyPacketBuf{busy};
+    Driver::Packet busyPacket = busyPacketBuf.toPacket();
+    EXPECT_CALL(mockDriver, allocPacket()).WillOnce(Return(busyPacket));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&busyPacket), _, _)).Times(1);
+    EXPECT_CALL(mockDriver, releasePackets(EqPacket(&busyPacket), Eq(1)))
         .Times(1);
 
     // Expect no data to be sent but the RESEND packet to be release.
-    EXPECT_CALL(mockDriver, sendPacket(Eq(&dataPacket), _, _)).Times(0);
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&dataPacket), _, _)).Times(0);
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleResendPacket(&mockPacket);
@@ -533,7 +548,7 @@ TEST_F(SenderTest, handleGrantPacket_basic)
     header->byteLimit = 7000;
     header->priority = 6;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleGrantPacket(&mockPacket);
@@ -542,7 +557,7 @@ TEST_F(SenderTest, handleGrantPacket_basic)
     EXPECT_EQ(6, info->priority);
     EXPECT_EQ(11000U, message->messageTimeout.expirationCycleTime);
     EXPECT_EQ(10100U, message->pingTimeout.expirationCycleTime);
-    EXPECT_TRUE(sender->sendReady.load());
+    EXPECT_TRUE(sender->sendReady);
 }
 
 TEST_F(SenderTest, handleGrantPacket_excessiveGrant)
@@ -565,7 +580,7 @@ TEST_F(SenderTest, handleGrantPacket_excessiveGrant)
     header->byteLimit = 11000;
     header->priority = 6;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -589,7 +604,7 @@ TEST_F(SenderTest, handleGrantPacket_excessiveGrant)
     EXPECT_EQ(6, info->priority);
     EXPECT_EQ(11000U, message->messageTimeout.expirationCycleTime);
     EXPECT_EQ(10100U, message->pingTimeout.expirationCycleTime);
-    EXPECT_TRUE(sender->sendReady.load());
+    EXPECT_TRUE(sender->sendReady);
 }
 
 TEST_F(SenderTest, handleGrantPacket_staleGrant)
@@ -611,7 +626,7 @@ TEST_F(SenderTest, handleGrantPacket_staleGrant)
     header->byteLimit = 4000;
     header->priority = 6;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleGrantPacket(&mockPacket);
@@ -620,7 +635,7 @@ TEST_F(SenderTest, handleGrantPacket_staleGrant)
     EXPECT_EQ(2, info->priority);
     EXPECT_EQ(11000U, message->messageTimeout.expirationCycleTime);
     EXPECT_EQ(10100U, message->pingTimeout.expirationCycleTime);
-    EXPECT_FALSE(sender->sendReady.load());
+    EXPECT_FALSE(sender->sendReady);
 }
 
 TEST_F(SenderTest, handleGrantPacket_dropGrant)
@@ -631,7 +646,7 @@ TEST_F(SenderTest, handleGrantPacket_dropGrant)
     header->common.messageId = id;
     header->byteLimit = 4000;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleGrantPacket(&mockPacket);
@@ -646,13 +661,14 @@ TEST_F(SenderTest, handleUnknownPacket_basic)
 
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
-    std::vector<Homa::Mock::MockDriver::MockPacket*> packets;
+    std::vector<Driver::Packet> packets;
     char payload[5][1028];
     for (int i = 0; i < 5; ++i) {
-        Homa::Mock::MockDriver::MockPacket* packet =
-            new Homa::Mock::MockDriver::MockPacket{payload[i]};
+        Homa::Mock::MockDriver::PacketBuf* packetBuf =
+            new Homa::Mock::MockDriver::PacketBuf{payload[i]};
+        Driver::Packet packet = packetBuf->toPacket();
         Protocol::Packet::DataHeader* header =
-            static_cast<Protocol::Packet::DataHeader*>(packet->payload);
+            static_cast<Protocol::Packet::DataHeader*>(packet.payload);
         header->policyVersion = policyOld.version;
         header->unscheduledIndexLimit = 2;
         packets.push_back(packet);
@@ -682,16 +698,15 @@ TEST_F(SenderTest, handleUnknownPacket_basic)
         mockPolicyManager,
         getUnscheduledPolicy(Eq(destination.ip), Eq(message->messageLength)))
         .WillOnce(Return(policyNew));
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleUnknownPacket(&mockPacket);
 
     EXPECT_EQ(Homa::OutMessage::Status::IN_PROGRESS, message->state);
     for (int i = 0; i < 3; ++i) {
-        Homa::Mock::MockDriver::MockPacket* packet = packets[i];
         Protocol::Packet::DataHeader* header =
-            static_cast<Protocol::Packet::DataHeader*>(packet->payload);
+            static_cast<Protocol::Packet::DataHeader*>(packets[i].payload);
         EXPECT_EQ(policyNew.version, header->policyVersion);
         EXPECT_EQ(3U, header->unscheduledIndexLimit);
     }
@@ -702,10 +717,11 @@ TEST_F(SenderTest, handleUnknownPacket_basic)
     EXPECT_EQ(policyNew.priority, info->priority);
     EXPECT_EQ(0U, info->packetsSent);
     EXPECT_TRUE(sender->sendQueue.contains(&info->sendQueueNode));
-    EXPECT_TRUE(sender->sendReady.load());
+    EXPECT_TRUE(sender->sendReady);
 
     for (int i = 0; i < 5; ++i) {
-        delete packets[i];
+        uintptr_t packetBuf = packets[i].descriptor;
+        delete (Homa::Mock::MockDriver::PacketBuf*) packetBuf;
     }
 }
 
@@ -718,12 +734,13 @@ TEST_F(SenderTest, handleUnknownPacket_singlePacketMessage)
 
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
-    Homa::Mock::MockDriver::MockPacket dataPacket{payload};
+    Homa::Mock::MockDriver::PacketBuf dataPacketBuf{payload};
+    Driver::Packet dataPacket = dataPacketBuf.toPacket();
     Protocol::Packet::DataHeader* dataHeader =
         static_cast<Protocol::Packet::DataHeader*>(dataPacket.payload);
     dataHeader->policyVersion = policyOld.version;
     dataHeader->unscheduledIndexLimit = 2;
-    setMessagePacket(message, 0, &dataPacket);
+    setMessagePacket(message, 0, dataPacket);
     message->destination = destination;
     message->messageLength = 500;
     message->state.store(Homa::OutMessage::Status::SENT);
@@ -741,8 +758,8 @@ TEST_F(SenderTest, handleUnknownPacket_singlePacketMessage)
         mockPolicyManager,
         getUnscheduledPolicy(Eq(destination.ip), Eq(message->messageLength)))
         .WillOnce(Return(policyNew));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(&dataPacket), _, _)).Times(1);
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, sendPacket(Eq(message->packets), _, _)).Times(1);
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleUnknownPacket(&mockPacket);
@@ -754,7 +771,7 @@ TEST_F(SenderTest, handleUnknownPacket_singlePacketMessage)
     EXPECT_EQ(10100U, message->pingTimeout.expirationCycleTime);
     EXPECT_FALSE(
         sender->sendQueue.contains(&message->queuedMessageInfo.sendQueueNode));
-    EXPECT_FALSE(sender->sendReady.load());
+    EXPECT_FALSE(sender->sendReady);
 }
 
 TEST_F(SenderTest, handleUnknownPacket_NO_RETRY)
@@ -764,13 +781,14 @@ TEST_F(SenderTest, handleUnknownPacket_NO_RETRY)
 
     Sender::MessageBucket* bucket = sender->messageBuckets.getBucket(id);
     Sender::Message* message =
-        dynamic_cast<Sender::Message*>(sender->allocMessage());
+        dynamic_cast<Sender::Message*>(sender->allocMessage(0));
     message->options = OutMessage::Options::NO_RETRY;
-    std::vector<Homa::Mock::MockDriver::MockPacket*> packets;
+    std::vector<Driver::Packet> packets;
     char payload[5][1028];
     for (int i = 0; i < 5; ++i) {
-        Homa::Mock::MockDriver::MockPacket* packet =
-            new Homa::Mock::MockDriver::MockPacket{payload[i]};
+        Homa::Mock::MockDriver::PacketBuf* packetBuf =
+            new Homa::Mock::MockDriver::PacketBuf{payload[i]};
+        Driver::Packet packet = packetBuf->toPacket();
         packets.push_back(packet);
         setMessagePacket(message, i, packet);
     }
@@ -787,10 +805,10 @@ TEST_F(SenderTest, handleUnknownPacket_NO_RETRY)
         static_cast<Protocol::Packet::UnknownHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
-    sender->handleUnknownPacket(&mockPacket, &mockDriver);
+    sender->handleUnknownPacket(&mockPacket);
 
     EXPECT_FALSE(
         sender->sendQueue.contains(&message->queuedMessageInfo.sendQueueNode));
@@ -798,7 +816,7 @@ TEST_F(SenderTest, handleUnknownPacket_NO_RETRY)
     EXPECT_EQ(nullptr, message->pingTimeout.node.list);
     EXPECT_EQ(Homa::OutMessage::Status::FAILED, message->state);
     EXPECT_EQ(Homa::OutMessage::Status::FAILED, message->state);
-    EXPECT_FALSE(sender->sendReady.load());
+    EXPECT_FALSE(sender->sendReady);
 }
 
 TEST_F(SenderTest, handleUnknownPacket_no_message)
@@ -809,7 +827,7 @@ TEST_F(SenderTest, handleUnknownPacket_no_message)
         static_cast<Protocol::Packet::UnknownHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleUnknownPacket(&mockPacket);
@@ -829,7 +847,7 @@ TEST_F(SenderTest, handleUnknownPacket_done)
         static_cast<Protocol::Packet::UnknownHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleUnknownPacket(&mockPacket);
@@ -854,7 +872,7 @@ TEST_F(SenderTest, handleErrorPacket_basic)
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleErrorPacket(&mockPacket);
@@ -877,7 +895,7 @@ TEST_F(SenderTest, handleErrorPacket_CANCELED)
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     sender->handleErrorPacket(&mockPacket);
@@ -898,7 +916,7 @@ TEST_F(SenderTest, handleErrorPacket_NOT_STARTED)
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -934,7 +952,7 @@ TEST_F(SenderTest, handleErrorPacket_IN_PROGRESS)
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -970,7 +988,7 @@ TEST_F(SenderTest, handleErrorPacket_COMPLETED)
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -1006,7 +1024,7 @@ TEST_F(SenderTest, handleErrorPacket_FAILED)
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
 
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
 
     VectorHandler handler;
@@ -1033,15 +1051,9 @@ TEST_F(SenderTest, handleErrorPacket_noMessage)
     Protocol::Packet::ErrorHeader* header =
         static_cast<Protocol::Packet::ErrorHeader*>(mockPacket.payload);
     header->common.messageId = id;
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, releasePackets(Eq(&mockPacket), Eq(1)))
         .Times(1);
     sender->handleErrorPacket(&mockPacket);
-}
-
-TEST_F(SenderTest, poll)
-{
-    // Nothing to test.
-    sender->poll();
 }
 
 TEST_F(SenderTest, checkTimeouts)
@@ -1094,8 +1106,8 @@ TEST_F(SenderTest, Message_append_basic)
         .WillByDefault(Return(MAX_RAW_PACKET_LENGTH));
     Sender::Message msg(sender, 0);
     char buf[2 * MAX_RAW_PACKET_LENGTH];
-    Homa::Mock::MockDriver::MockPacket packet0{buf + 0};
-    Homa::Mock::MockDriver::MockPacket packet1{buf + MAX_RAW_PACKET_LENGTH};
+    Homa::Mock::MockDriver::PacketBuf packetBuf0{buf + 0};
+    Homa::Mock::MockDriver::PacketBuf packetBuf1{buf + MAX_RAW_PACKET_LENGTH};
 
     const int TRANSPORT_HEADER_LENGTH = msg.TRANSPORT_HEADER_LENGTH;
     const int PACKET_DATA_LENGTH = msg.PACKET_DATA_LENGTH;
@@ -1104,19 +1116,19 @@ TEST_F(SenderTest, Message_append_basic)
               TRANSPORT_HEADER_LENGTH + PACKET_DATA_LENGTH);
 
     char source[] = "Hello, world!";
-    setMessagePacket(&msg, 0, &packet0);
-    packet0.length = MAX_RAW_PACKET_LENGTH - 7;
+    setMessagePacket(&msg, 0, packetBuf0.toPacket(MAX_RAW_PACKET_LENGTH - 7));
     msg.messageLength = PACKET_DATA_LENGTH - 7;
 
-    EXPECT_CALL(mockDriver, allocPacket).WillOnce(Return(&packet1));
+    EXPECT_CALL(mockDriver, allocPacket)
+        .WillOnce(Return(packetBuf1.toPacket()));
 
     msg.append(source, 14);
 
     EXPECT_EQ(PACKET_DATA_LENGTH + 7, msg.messageLength);
     EXPECT_EQ(2U, msg.numPackets);
-    EXPECT_TRUE(msg.packets[1] == &packet1);
-    EXPECT_EQ(MAX_RAW_PACKET_LENGTH, packet0.length);
-    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + 7, packet1.length);
+    EXPECT_EQ(msg.packets[1].payload, packetBuf1.buffer);
+    EXPECT_EQ(MAX_RAW_PACKET_LENGTH, msg.packets[0].length);
+    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + 7, msg.packets[1].length);
     EXPECT_TRUE(std::memcmp(buf + MAX_RAW_PACKET_LENGTH - 7, source, 7) == 0);
     EXPECT_TRUE(
         std::memcmp(buf + MAX_RAW_PACKET_LENGTH + TRANSPORT_HEADER_LENGTH,
@@ -1133,16 +1145,13 @@ TEST_F(SenderTest, Message_append_truncated)
     ON_CALL(mockDriver, getMaxPayloadSize)
         .WillByDefault(Return(MAX_RAW_PACKET_LENGTH));
     Sender::Message msg(sender, 0);
-    char buf[2 * MAX_RAW_PACKET_LENGTH];
-    Homa::Mock::MockDriver::MockPacket packet0{buf + 0};
-    Homa::Mock::MockDriver::MockPacket packet1{buf + MAX_RAW_PACKET_LENGTH};
-
-    const int TRANSPORT_HEADER_LENGTH = msg.TRANSPORT_HEADER_LENGTH;
-    const int PACKET_DATA_LENGTH = msg.PACKET_DATA_LENGTH;
+    char buf[MAX_RAW_PACKET_LENGTH];
+    Homa::Mock::MockDriver::PacketBuf packetBuf{buf};
 
     char source[] = "Hello, world!";
-    setMessagePacket(&msg, msg.MAX_MESSAGE_PACKETS - 1, &packet0);
-    packet0.length = msg.TRANSPORT_HEADER_LENGTH + msg.PACKET_DATA_LENGTH - 7;
+    setMessagePacket(&msg, msg.MAX_MESSAGE_PACKETS - 1, packetBuf.toPacket());
+    Driver::Packet& packet = msg.packets[msg.MAX_MESSAGE_PACKETS - 1];
+    packet.length = msg.TRANSPORT_HEADER_LENGTH + msg.PACKET_DATA_LENGTH - 7;
     msg.messageLength = msg.PACKET_DATA_LENGTH * msg.MAX_MESSAGE_PACKETS - 7;
     EXPECT_EQ(1U, msg.numPackets);
 
@@ -1152,7 +1161,7 @@ TEST_F(SenderTest, Message_append_truncated)
               msg.messageLength);
     EXPECT_EQ(1U, msg.numPackets);
     EXPECT_EQ(msg.TRANSPORT_HEADER_LENGTH + msg.PACKET_DATA_LENGTH,
-              packet0.length);
+              packet.length);
     EXPECT_TRUE(std::memcmp(buf + MAX_RAW_PACKET_LENGTH - 7, source, 7) == 0);
 
     EXPECT_EQ(1U, handler.messages.size());
@@ -1180,7 +1189,7 @@ TEST_F(SenderTest, Message_getStatus)
 TEST_F(SenderTest, Message_length)
 {
     ON_CALL(mockDriver, getMaxPayloadSize).WillByDefault(Return(2048));
-    Sender::Message msg(sender, &mockDriver);
+    Sender::Message msg(sender, 0);
     msg.messageLength = 200;
     msg.start = 20;
     EXPECT_EQ(180U, msg.length());
@@ -1191,14 +1200,16 @@ TEST_F(SenderTest, Message_prepend)
     ON_CALL(mockDriver, getMaxPayloadSize).WillByDefault(Return(2048));
     Sender::Message msg(sender, 0);
     char buf[4096];
-    Homa::Mock::MockDriver::MockPacket packet0{buf + 0};
-    Homa::Mock::MockDriver::MockPacket packet1{buf + 2048};
+    Homa::Mock::MockDriver::PacketBuf packetBuf0{buf + 0};
+    Homa::Mock::MockDriver::PacketBuf packetBuf1{buf + 2048};
+    Driver::Packet packet0 = packetBuf0.toPacket();
+    Driver::Packet packet1 = packetBuf1.toPacket();
 
     const int TRANSPORT_HEADER_LENGTH = msg.TRANSPORT_HEADER_LENGTH;
     const int PACKET_DATA_LENGTH = msg.PACKET_DATA_LENGTH;
     EXPECT_CALL(mockDriver, allocPacket)
-        .WillOnce(Return(&packet0))
-        .WillOnce(Return(&packet1));
+        .WillOnce(Return(packet0))
+        .WillOnce(Return(packet1));
     msg.reserve(PACKET_DATA_LENGTH + 7);
     EXPECT_EQ(PACKET_DATA_LENGTH + 7, msg.start);
     EXPECT_EQ(PACKET_DATA_LENGTH + 7, msg.messageLength);
@@ -1226,8 +1237,8 @@ TEST_F(SenderTest, Message_reserve)
 {
     Sender::Message msg(sender, 0);
     char buf[4096];
-    Homa::Mock::MockDriver::MockPacket packet0{buf + 0};
-    Homa::Mock::MockDriver::MockPacket packet1{buf + 2048};
+    Homa::Mock::MockDriver::PacketBuf packetBuf0{buf + 0};
+    Homa::Mock::MockDriver::PacketBuf packetBuf1{buf + 2048};
 
     const int TRANSPORT_HEADER_LENGTH = msg.TRANSPORT_HEADER_LENGTH;
     const int PACKET_DATA_LENGTH = msg.PACKET_DATA_LENGTH;
@@ -1236,26 +1247,28 @@ TEST_F(SenderTest, Message_reserve)
     EXPECT_EQ(0U, msg.messageLength);
     EXPECT_EQ(0U, msg.numPackets);
 
-    EXPECT_CALL(mockDriver, allocPacket).WillOnce(Return(&packet0));
+    EXPECT_CALL(mockDriver, allocPacket)
+        .WillOnce(Return(packetBuf0.toPacket()));
 
     msg.reserve(PACKET_DATA_LENGTH - 7);
 
     EXPECT_EQ(PACKET_DATA_LENGTH - 7, msg.start);
     EXPECT_EQ(PACKET_DATA_LENGTH - 7, msg.messageLength);
     EXPECT_EQ(1U, msg.numPackets);
-    EXPECT_EQ(&packet0, msg.getPacket(0));
-    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + PACKET_DATA_LENGTH - 7, packet0.length);
+    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + PACKET_DATA_LENGTH - 7,
+        msg.packets[0].length);
 
-    EXPECT_CALL(mockDriver, allocPacket).WillOnce(Return(&packet1));
+    EXPECT_CALL(mockDriver, allocPacket)
+        .WillOnce(Return(packetBuf1.toPacket()));
 
     msg.reserve(14);
 
     EXPECT_EQ(PACKET_DATA_LENGTH + 7, msg.start);
     EXPECT_EQ(PACKET_DATA_LENGTH + 7, msg.messageLength);
     EXPECT_EQ(2U, msg.numPackets);
-    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + PACKET_DATA_LENGTH, packet0.length);
-    EXPECT_EQ(&packet1, msg.getPacket(1));
-    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + 7, packet1.length);
+    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + PACKET_DATA_LENGTH,
+        msg.packets[0].length);
+    EXPECT_EQ(TRANSPORT_HEADER_LENGTH + 7, msg.packets[1].length);
 }
 
 TEST_F(SenderTest, Message_send)
@@ -1266,8 +1279,8 @@ TEST_F(SenderTest, Message_send)
 TEST_F(SenderTest, Message_getPacket)
 {
     Sender::Message msg(sender, 0);
-    Driver::Packet* packet = (Driver::Packet*)42;
-    msg.packets[0] = packet;
+    msg.packets[0] = {};
+    Driver::Packet* packet = &msg.packets[0];
 
     EXPECT_EQ(nullptr, msg.getPacket(0));
 
@@ -1281,19 +1294,21 @@ TEST_F(SenderTest, Message_getOrAllocPacket)
     // TODO(cstlee): cleanup
     Sender::Message msg(sender, 0);
     char buf[4096];
-    Homa::Mock::MockDriver::MockPacket packet0{buf + 0};
-    Homa::Mock::MockDriver::MockPacket packet1{buf + 2048};
+    Homa::Mock::MockDriver::PacketBuf packetBuf0{buf + 0};
+    Homa::Mock::MockDriver::PacketBuf packetBuf1{buf + 2048};
+    Driver::Packet packet0 = packetBuf0.toPacket();
+    Driver::Packet packet1 = packetBuf1.toPacket();
 
     EXPECT_FALSE(msg.occupied.test(0));
     EXPECT_EQ(0U, msg.numPackets);
-    EXPECT_CALL(mockDriver, allocPacket).WillOnce(Return(&packet0));
+    EXPECT_CALL(mockDriver, allocPacket).WillOnce(Return(packet0));
 
-    EXPECT_TRUE(&packet0 == msg.getOrAllocPacket(0));
+    EXPECT_EQ(packet0.descriptor, msg.getOrAllocPacket(0)->descriptor);
 
     EXPECT_TRUE(msg.occupied.test(0));
     EXPECT_EQ(1U, msg.numPackets);
 
-    EXPECT_TRUE(&packet0 == msg.getOrAllocPacket(0));
+    EXPECT_EQ(packet0.descriptor, msg.getOrAllocPacket(0)->descriptor);
 
     EXPECT_TRUE(msg.occupied.test(0));
     EXPECT_EQ(1U, msg.numPackets);
@@ -1341,7 +1356,8 @@ TEST_F(SenderTest, sendMessage_basic)
         dynamic_cast<Sender::Message*>(sender->allocMessage(sport));
     Sender::MessageBucket* bucket = sender->messageBuckets.getBucket(id);
 
-    setMessagePacket(message, 0, &mockPacket);
+    setMessagePacket(message, 0, mockPacket);
+    Driver::Packet& mockPacket = message->packets[0];
     message->messageLength = 420;
     mockPacket.length =
         message->messageLength + message->TRANSPORT_HEADER_LENGTH;
@@ -1387,23 +1403,26 @@ TEST_F(SenderTest, sendMessage_basic)
     EXPECT_EQ(policy.priority, mockPriority);
 
     EXPECT_EQ(Homa::OutMessage::Status::SENT, message->state);
-    EXPECT_FALSE(sender->sendReady.load());
+    EXPECT_FALSE(sender->sendReady);
 }
 
 TEST_F(SenderTest, sendMessage_multipacket)
 {
     char payload0[1027];
     char payload1[1027];
-    Homa::Mock::MockDriver::MockPacket packet0{payload0};
-    Homa::Mock::MockDriver::MockPacket packet1{payload1};
+    Homa::Mock::MockDriver::PacketBuf packetBuf0{payload0};
+    Homa::Mock::MockDriver::PacketBuf packetBuf1{payload1};
     Protocol::MessageId id = {sender->transportId,
                               sender->nextMessageSequenceNumber};
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
     Sender::MessageBucket* bucket = sender->messageBuckets.getBucket(id);
 
-    setMessagePacket(message, 0, &packet0);
-    setMessagePacket(message, 1, &packet1);
+    setMessagePacket(message, 0, packetBuf0.toPacket());
+    setMessagePacket(message, 1, packetBuf1.toPacket());
+    Driver::Packet& packet0 = message->packets[0];
+    Driver::Packet& packet1 = message->packets[1];
+
     message->messageLength = 1420;
     packet0.length = 1000 + 31;
     packet1.length = 420 + 31;
@@ -1446,7 +1465,7 @@ TEST_F(SenderTest, sendMessage_multipacket)
     // Check sendQueue metadata
     Sender::QueuedMessageInfo* info = &message->queuedMessageInfo;
     EXPECT_TRUE(sender->sendQueue.contains(&info->sendQueueNode));
-    EXPECT_TRUE(sender->sendReady.load());
+    EXPECT_TRUE(sender->sendReady);
 }
 
 TEST_F(SenderTest, sendMessage_missingPacket)
@@ -1455,7 +1474,7 @@ TEST_F(SenderTest, sendMessage_missingPacket)
                               sender->nextMessageSequenceNumber};
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
-    setMessagePacket(message, 1, &mockPacket);
+    setMessagePacket(message, 1, mockPacket);
     Core::Policy::Unscheduled policy = {1, 1000, 2};
     ON_CALL(mockPolicyManager, getUnscheduledPolicy(_, _))
         .WillByDefault(Return(policy));
@@ -1472,10 +1491,10 @@ TEST_F(SenderTest, sendMessage_unscheduledLimit)
     Sender::Message* message =
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
     for (int i = 0; i < 9; ++i) {
-        setMessagePacket(message, i, &mockPacket);
+        mockPacket.length = 1000 + sizeof(Protocol::Packet::DataHeader);
+        setMessagePacket(message, i, mockPacket);
     }
     message->messageLength = 9000;
-    mockPacket.length = 1000 + sizeof(Protocol::Packet::DataHeader);
     SocketAddress destination = {22, 60001};
     Core::Policy::Unscheduled policy = {1, 4500, 2};
     EXPECT_EQ(9U, message->numPackets);
@@ -1618,9 +1637,9 @@ TEST_F(SenderTest, checkPingTimeouts_basic)
 
     EXPECT_EQ(10000U, PerfUtils::Cycles::rdtsc());
 
-    EXPECT_CALL(mockDriver, allocPacket()).WillOnce(Return(&mockPacket));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(&mockPacket), _, _)).Times(1);
-    EXPECT_CALL(mockDriver, releasePackets(Pointee(&mockPacket), Eq(1)))
+    EXPECT_CALL(mockDriver, allocPacket()).WillOnce(Return(mockPacket));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&mockPacket), _, _)).Times(1);
+    EXPECT_CALL(mockDriver, releasePackets(EqPacket(&mockPacket), Eq(1)))
         .Times(1);
 
     uint64_t nextTimeout = sender->checkPingTimeouts();
@@ -1661,13 +1680,15 @@ TEST_F(SenderTest, trySend_basic)
         dynamic_cast<Sender::Message*>(sender->allocMessage(0));
     Sender::QueuedMessageInfo* info = &message->queuedMessageInfo;
     SenderTest::addMessage(sender, id, message, true, 3);
-    Homa::Mock::MockDriver::MockPacket* packet[5];
+    Driver::Packet packet[5];
+    uint64_t waitUntil;
     const uint32_t PACKET_SIZE = sender->driver->getMaxPayloadSize();
     const uint32_t PACKET_DATA_SIZE =
         PACKET_SIZE - message->TRANSPORT_HEADER_LENGTH;
     for (int i = 0; i < 5; ++i) {
-        packet[i] = new Homa::Mock::MockDriver::MockPacket{payload};
-        packet[i]->length = PACKET_SIZE;
+        auto* packetBuf = new Homa::Mock::MockDriver::PacketBuf{payload};
+        packet[i] = packetBuf->toPacket();
+        packet[i].length = PACKET_SIZE;
         setMessagePacket(message, i, packet[i]);
         info->unsentBytes += PACKET_DATA_SIZE;
     }
@@ -1681,9 +1702,9 @@ TEST_F(SenderTest, trySend_basic)
     EXPECT_TRUE(sender->sendQueue.contains(&info->sendQueueNode));
 
     // 3 granted packets; 2 will send; queue limit reached.
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[0]), _, _));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[1]), _, _));
-    sender->trySend();  // < test call
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[0]), _, _));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[1]), _, _));
+    sender->trySend(&waitUntil);  // < test call
     EXPECT_TRUE(sender->sendReady);
     EXPECT_EQ(Homa::OutMessage::Status::IN_PROGRESS, message->state);
     EXPECT_EQ(3U, info->packetsGranted);
@@ -1694,8 +1715,8 @@ TEST_F(SenderTest, trySend_basic)
     Mock::VerifyAndClearExpectations(&mockDriver);
 
     // 1 packet to be sent; grant limit reached.
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[2]), _, _));
-    sender->trySend();  // < test call
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[2]), _, _));
+    sender->trySend(&waitUntil);  // < test call
     EXPECT_FALSE(sender->sendReady);
     EXPECT_EQ(Homa::OutMessage::Status::IN_PROGRESS, message->state);
     EXPECT_EQ(3U, info->packetsGranted);
@@ -1708,7 +1729,7 @@ TEST_F(SenderTest, trySend_basic)
     // No additional grants; spurious ready hint.
     EXPECT_CALL(mockDriver, sendPacket).Times(0);
     sender->sendReady = true;
-    sender->trySend();  // < test call
+    sender->trySend(&waitUntil);  // < test call
     EXPECT_FALSE(sender->sendReady);
     EXPECT_EQ(Homa::OutMessage::Status::IN_PROGRESS, message->state);
     EXPECT_EQ(3U, info->packetsGranted);
@@ -1721,9 +1742,9 @@ TEST_F(SenderTest, trySend_basic)
     // 2 more granted packets; will finish.
     info->packetsGranted = 5;
     sender->sendReady = true;
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[3]), _, _));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[4]), _, _));
-    sender->trySend();  // < test call
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[3]), _, _));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[4]), _, _));
+    sender->trySend(&waitUntil);  // < test call
     EXPECT_FALSE(sender->sendReady);
     EXPECT_EQ(Homa::OutMessage::Status::SENT, message->state);
     EXPECT_EQ(5U, info->packetsGranted);
@@ -1734,7 +1755,8 @@ TEST_F(SenderTest, trySend_basic)
     Mock::VerifyAndClearExpectations(&mockDriver);
 
     for (int i = 0; i < 5; ++i) {
-        delete packet[i];
+        uintptr_t packetBuf = packet[i].descriptor;
+        delete (Homa::Mock::MockDriver::PacketBuf*) packetBuf;
     }
 }
 
@@ -1742,17 +1764,18 @@ TEST_F(SenderTest, trySend_multipleMessages)
 {
     Sender::Message* message[3];
     Sender::QueuedMessageInfo* info[3];
-    Homa::Mock::MockDriver::MockPacket* packet[3];
+    Driver::Packet packet[3];
     for (uint64_t i = 0; i < 3; ++i) {
         Protocol::MessageId id = {22, 10 + i};
         message[i] = dynamic_cast<Sender::Message*>(sender->allocMessage(0));
         info[i] = &message[i]->queuedMessageInfo;
         SenderTest::addMessage(sender, id, message[i], true, 1);
-        packet[i] = new Homa::Mock::MockDriver::MockPacket{payload};
-        packet[i]->length = sender->driver->getMaxPayloadSize() / 4;
+        auto* packetBuf = new Homa::Mock::MockDriver::PacketBuf{payload};
+        packet[i] = packetBuf->toPacket();
+        packet[i].length = sender->driver->getMaxPayloadSize() / 4;
         setMessagePacket(message[i], 0, packet[i]);
         info[i]->unsentBytes +=
-            (packet[i]->length - message[i]->TRANSPORT_HEADER_LENGTH);
+            (packet[i].length - message[i]->TRANSPORT_HEADER_LENGTH);
         message[i]->state = Homa::OutMessage::Status::IN_PROGRESS;
     }
     sender->sendReady = true;
@@ -1764,19 +1787,21 @@ TEST_F(SenderTest, trySend_multipleMessages)
     // Message 1: Will reach grant limit
     EXPECT_EQ(1, info[1]->packetsGranted);
     info[1]->packetsSent = 0;
-    setMessagePacket(message[1], 1, nullptr);
+    setMessagePacket(message[1], 1, {});
     EXPECT_EQ(2, message[1]->numPackets);
 
     // Message 2: Will finish
     EXPECT_EQ(1, info[2]->packetsGranted);
     info[2]->packetsSent = 0;
 
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[0]), _, _));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[1]), _, _));
-    EXPECT_CALL(mockDriver, sendPacket(Eq(packet[2]), _, _));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[0]), _, _));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[1]), _, _));
+    EXPECT_CALL(mockDriver, sendPacket(EqPacket(&packet[2]), _, _));
 
-    sender->trySend();
+    uint64_t waitUntil;
+    bool sendReady = sender->trySend(&waitUntil);
 
+    EXPECT_FALSE(sendReady);
     EXPECT_EQ(1U, info[0]->packetsSent);
     EXPECT_EQ(Homa::OutMessage::Status::SENT, message[0]->state);
     EXPECT_FALSE(sender->sendQueue.contains(&info[0]->sendQueueNode));
@@ -1788,33 +1813,14 @@ TEST_F(SenderTest, trySend_multipleMessages)
     EXPECT_FALSE(sender->sendQueue.contains(&info[2]->sendQueueNode));
 }
 
-TEST_F(SenderTest, trySend_alreadyRunning)
-{
-    Protocol::MessageId id = {42, 1};
-    Sender::Message* message =
-        dynamic_cast<Sender::Message*>(sender->allocMessage(0));
-    Sender::QueuedMessageInfo* info = &message->queuedMessageInfo;
-    SenderTest::addMessage(sender, id, message, true, 1);
-    setMessagePacket(message, 0, &mockPacket);
-    message->messageLength = 1000;
-    EXPECT_EQ(1U, message->numPackets);
-    EXPECT_EQ(1, info->packetsGranted);
-    EXPECT_EQ(0, info->packetsSent);
-
-    sender->sending.test_and_set();
-
-    EXPECT_CALL(mockDriver, sendPacket).Times(0);
-
-    sender->trySend();
-
-    EXPECT_EQ(0, info->packetsSent);
-}
-
 TEST_F(SenderTest, trySend_nothingToSend)
 {
     EXPECT_TRUE(sender->sendQueue.empty());
     EXPECT_CALL(mockDriver, sendPacket).Times(0);
-    sender->trySend();
+    uint64_t waitUntil = 0;
+    bool sendReady = sender->trySend(&waitUntil);
+    EXPECT_FALSE(sendReady);
+    EXPECT_EQ(waitUntil, 0);
 }
 
 }  // namespace

--- a/src/Shenango.cc
+++ b/src/Shenango.cc
@@ -1,0 +1,259 @@
+/* Copyright (c) 2020, Stanford University
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "Debug.h"
+#include "Homa/Homa.h"
+#include "Homa/Shenango.h"
+
+using namespace Homa;
+
+/**
+ * Shorthand for declaring "extern" function pointers to Shenango functions.
+ * These functions pointers will be initialized on the Shenango side in homa.c.
+ */
+#define DECLARE_SHENANGO_FUNC(ReturnType, MethodName, ...)  \
+    extern ReturnType (*shenango_##MethodName) (__VA_ARGS__);
+
+/**
+ * Fast thread-local slab-based memory allocation.
+ */
+DECLARE_SHENANGO_FUNC(void*, smalloc, size_t)
+DECLARE_SHENANGO_FUNC(void, sfree, void*)
+
+/**
+ * Protect RCU read-side critical sections.
+ */
+DECLARE_SHENANGO_FUNC(void, rcu_read_lock)
+DECLARE_SHENANGO_FUNC(void, rcu_read_unlock)
+
+/**
+ * Allocate a Shenango mbuf struct to hold an egress Homa packet.
+ */
+DECLARE_SHENANGO_FUNC(void*, homa_tx_alloc_mbuf, void**)
+
+/**
+ * Free a packet buffer allocated earlier.
+ */
+DECLARE_SHENANGO_FUNC(void, mbuf_free, void*)
+
+/**
+ * Transmit an IP packet using Shenango's driver stack.
+ */
+DECLARE_SHENANGO_FUNC(int, homa_tx_ip,
+        uintptr_t, void*, int32_t, uint8_t, uint32_t, uint8_t)
+
+/**
+ * Deliver an ingress message to a homa socket in Shenango.
+ */
+DECLARE_SHENANGO_FUNC(void, homa_mb_deliver, void*, homa_inmsg)
+
+/**
+ * Return the number of bytes queued up in the transmit queue.
+ */
+DECLARE_SHENANGO_FUNC(uint32_t, homa_queued_bytes)
+
+/**
+ * Find a socket that matches the 5-tuple.
+ */
+DECLARE_SHENANGO_FUNC(void*, trans_table_lookup,
+        uint8_t, SocketAddress, SocketAddress)
+
+/**
+ * A simple shim driver that translates Driver operations to Shenango
+ * functions.
+ */
+class ShenangoDriver final : public Driver {
+  public:
+    explicit ShenangoDriver(uint8_t proto, uint32_t local_ip,
+                            uint32_t max_payload, uint32_t link_speed)
+        : Driver()
+        , proto(proto)
+        , local_ip{local_ip}
+        , max_payload(max_payload)
+        , link_speed(link_speed)
+    {}
+
+    Packet allocPacket() override
+    {
+        void* payload;
+        void* mbuf = shenango_homa_tx_alloc_mbuf(&payload);
+        return Packet{(uintptr_t) mbuf, payload, 0};
+    }
+
+    void
+    sendPacket(Packet* packet, IpAddress destination, int priority) override
+    {
+        shenango_homa_tx_ip(packet->descriptor, packet->payload, packet->length,
+                proto, (uint32_t)destination, (uint8_t)priority);
+    }
+
+    uint32_t
+    receivePackets(uint32_t maxPackets, Packet receivedPackets[],
+                   IpAddress sourceAddresses[]) override
+    {
+        (void)maxPackets;
+        (void)receivedPackets;
+        (void)sourceAddresses;
+        PANIC("receivePackets must not be called when used with Shenango");
+        return 0;
+    }
+
+    void
+    releasePackets(Packet packets[], uint16_t numPackets) override
+    {
+        for (uint16_t i = 0; i < numPackets; i++) {
+            shenango_mbuf_free((void*) packets[i].descriptor);
+        }
+    }
+
+    uint32_t getMaxPayloadSize() override { return max_payload; }
+
+    uint32_t getBandwidth() override { return link_speed; }
+
+    IpAddress getLocalAddress() override { return local_ip; }
+
+    uint32_t getQueuedBytes() override { return shenango_homa_queued_bytes(); }
+
+  private:
+    /// Protocol number reserved for Homa; defined as IPPROTO_HOMA in Shenango.
+    const uint8_t proto;
+
+    /// Local IP address of the driver.
+    const IpAddress local_ip;
+
+    /// # bytes in a payload
+    const uint32_t max_payload;
+
+    /// Effective network bandwidth, in Mbits/second.
+    const uint32_t link_speed;
+};
+
+homa_driver
+homa_driver_create(uint8_t proto, uint32_t local_ip, uint32_t max_payload,
+                   uint32_t link_speed)
+{
+    void* driver = new ShenangoDriver(proto, local_ip, max_payload, link_speed);
+    return homa_driver{driver};
+}
+
+void homa_driver_free(homa_driver drv)
+{
+    delete static_cast<ShenangoDriver*>(drv.p);
+}
+
+/**
+ * An almost trivial implementation of Mailbox.  This class is essentially
+ * a wrapper around a socket table entry in Shenango (i.e., struct trans_entry).
+ *
+ */
+class ShenangoMailbox final : public Mailbox {
+  public:
+    explicit ShenangoMailbox(void* trans_entry)
+        : trans_entry(trans_entry)
+    {}
+
+    ~ShenangoMailbox() override = default;
+
+    void close() override
+    {
+        this->~ShenangoMailbox();
+        shenango_sfree(this);
+        shenango_rcu_read_unlock();
+    }
+
+    void deliver(InMessage* message) override
+    {
+        shenango_homa_mb_deliver(trans_entry, homa_inmsg{message});
+    }
+
+    InMessage* retrieve(bool blocking) override
+    {
+        (void)blocking;
+        PANIC("Shenango should never call Homa::Socket::receive");
+    }
+
+    void socketShutdown() override
+    {
+        PANIC("Shenango should never call Homa::Socket::shutdown");
+    }
+
+  private:
+    /// An opaque pointer to "struct trans_entry" in Shenango.
+    void* const trans_entry;
+};
+
+/**
+ * An almost trivial implementation of MailboxDir that uses Shenango's RCU
+ * mechanism to prevent a mailbox from being destroyed until all readers have
+ * closed it.
+ *
+ * Note: Shenango doesn't use Homa::Socket to receive messages, so the only
+ * method that has a meaningful implementation is open().
+ */
+class ShenangoMailboxDir final : MailboxDir {
+  public:
+    explicit ShenangoMailboxDir(uint8_t proto, uint32_t local_ip)
+        : proto(proto)
+        , local_ip{local_ip}
+    {}
+
+    ~ShenangoMailboxDir() override = default;
+
+    Mailbox* alloc(uint16_t port) override
+    {
+        // Shenango doesn't rely on Homa::Socket to receive messages,
+        // so there is no need to assign a real mailbox to SocketImpl.
+        static ShenangoMailbox dummyMailbox(nullptr);
+        (void)port;
+        return &dummyMailbox;
+    }
+
+    Mailbox* open(uint16_t port) override
+    {
+        SocketAddress laddr = {local_ip, port};
+        shenango_rcu_read_lock();
+        void* trans_entry = shenango_trans_table_lookup(proto, laddr, {});
+        if (!trans_entry) {
+            return nullptr;
+        }
+        void* backing = shenango_smalloc(sizeof(ShenangoMailbox));
+        return new (backing) ShenangoMailbox(trans_entry);
+    }
+
+    bool remove(uint16_t port) override
+    {
+        // Nothing to do; Shenango is responsible for taking care of freeing
+        // the resources related to homa sockets.
+        (void)port;
+        return true;
+    }
+
+    /// Protocol number reserved for Homa; defined as IPPROTO_HOMA in Shenango.
+    const uint8_t proto;
+
+    /// Local IP address of the transport.
+    const IpAddress local_ip;
+};
+
+homa_mailbox_dir homa_mb_dir_create(uint8_t proto, uint32_t local_ip)
+{
+    void* dir = new ShenangoMailboxDir(proto, local_ip);
+    return homa_mailbox_dir{dir};
+}
+
+void homa_mb_dir_free(homa_mailbox_dir mailbox_dir)
+{
+    delete static_cast<ShenangoMailboxDir*>(mailbox_dir.p);
+}

--- a/src/SimpleMailboxDir.cc
+++ b/src/SimpleMailboxDir.cc
@@ -1,0 +1,171 @@
+/* Copyright (c) 2020, Stanford University
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <Homa/Utils/SimpleMailboxDir.h>
+#include "SpinLock.h"
+#include <list>
+
+namespace Homa {
+
+/**
+ * A simple reference implementation of Homa::Mailbox that uses polling to
+ * detect incoming messages.
+ */
+class MailboxImpl : public Mailbox {
+  public:
+    explicit MailboxImpl();
+    ~MailboxImpl() override;
+    void close() override;
+    void deliver(InMessage* message) override;
+    InMessage* retrieve(bool blocking) override;
+    void socketShutdown() override;
+
+    /// Protects the queue
+    SpinLock mutex;
+
+    /// Keeps track of the number of calls to open() without paired close().
+    /// It's initialized to one because, intuitively, a Socket must keep its
+    /// mailbox "open" in order to retrieve incoming messages.
+    std::atomic<int> openers;
+
+    /// Has the corresponding socket been shut down?
+    std::atomic<bool> shutdown;
+
+    /// List of completely received messages.
+    std::list<InMessage*> queue;
+};
+
+MailboxImpl::MailboxImpl()
+    : mutex()
+    , openers(1)
+    , shutdown()
+    , queue()
+{}
+
+MailboxImpl::~MailboxImpl()
+{
+    while (!queue.empty()) {
+        InMessage* message = queue.front();
+        queue.pop_front();
+        Homa::unique_ptr<InMessage> deleter(message);
+    }
+}
+
+/// See Homa::Mailbox::close()
+void
+MailboxImpl::close()
+{
+    if (openers.fetch_sub(1, std::memory_order_release) == 1) {
+        std::atomic_thread_fence(std::memory_order_acquire);
+
+        // MailboxImpl was instantiated via "new" in SimpleMailboxDir::alloc.
+        delete this;
+    }
+}
+
+/// See Homa::Mailbox::deliver()
+void
+MailboxImpl::deliver(InMessage* message)
+{
+    SpinLock::Lock _(mutex);
+    queue.push_back(message);
+}
+
+/// See Homa::Mailbox::retrieve()
+InMessage*
+MailboxImpl::retrieve(bool blocking)
+{
+    InMessage* message = nullptr;
+    do {
+        SpinLock::Lock _(mutex);
+        if (!queue.empty()) {
+            message = queue.front();
+            queue.pop_front();
+        }
+    } while (blocking && !shutdown.load(std::memory_order_relaxed));
+    return message;
+}
+
+/// See Homa::Mailbox::socketShutdown()
+void
+MailboxImpl::socketShutdown()
+{
+    shutdown.store(true);
+}
+
+SimpleMailboxDir::SimpleMailboxDir()
+    : mutex(new SpinLock())
+    , map()
+{}
+
+SimpleMailboxDir::~SimpleMailboxDir()
+{
+    for (auto entry : map) {
+        MailboxImpl* mailbox = entry.second;
+        mailbox->close();
+    }
+}
+
+Mailbox*
+SimpleMailboxDir::alloc(uint16_t port)
+{
+    MailboxImpl* mailbox = nullptr;
+    SpinLock::Lock _(*mutex);
+    auto it = map.find(port);
+    if (it == map.end()) {
+        mailbox = new MailboxImpl();
+        map[port] = mailbox;
+    }
+    return mailbox;
+}
+
+Mailbox*
+SimpleMailboxDir::open(uint16_t port)
+{
+    MailboxImpl* mailbox = nullptr;
+    {
+        // Look up the mailbox
+        SpinLock::Lock _(*mutex);
+        auto it = map.find(port);
+        if (it != map.end()) {
+            mailbox = it->second;
+        }
+    }
+
+    // Increment the reference count of the mailbox.
+    if (mailbox) {
+        mailbox->openers.fetch_add(1, std::memory_order_relaxed);
+    }
+    return mailbox;
+}
+
+bool
+SimpleMailboxDir::remove(uint16_t port)
+{
+    MailboxImpl* mailbox;
+    {
+        SpinLock::Lock _(*mutex);
+        auto it = map.find(port);
+        if (it == map.end()) {
+            return false;
+        }
+        mailbox = it->second;
+        map.erase(it);
+    }
+    mailbox->close();
+    return true;
+}
+
+}  // namespace Homa

--- a/src/TransportImpl.h
+++ b/src/TransportImpl.h
@@ -20,10 +20,6 @@
 
 #include <atomic>
 #include <bitset>
-#include <deque>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
 
 #include "ObjectPool.h"
 #include "Policy.h"
@@ -34,32 +30,26 @@
 /**
  * Homa
  */
-namespace Homa {
-namespace Core {
+namespace Homa::Core {
 
 /**
  * Internal implementation of Homa::Transport.
- *
  */
-class TransportImpl : public Transport {
+class TransportImpl final : public Transport {
   public:
-    explicit TransportImpl(Driver* driver, uint64_t transportId);
+    explicit TransportImpl(Driver* driver, MailboxDir* mailboxDir,
+                           uint64_t transportId);
+    explicit TransportImpl(Driver* driver, MailboxDir* mailboxDir,
+                           Sender* sender, Receiver* receiver,
+                           uint64_t transportId);
     ~TransportImpl();
-
-    /// See Homa::Transport::alloc()
-    virtual Homa::unique_ptr<Homa::OutMessage> alloc(uint16_t sourcePort)
-    {
-        Homa::OutMessage* outMessage = sender->allocMessage(sourcePort);
-        return Homa::unique_ptr<Homa::OutMessage>(outMessage);
-    }
-
-    /// See Homa::Transport::receive()
-    virtual Homa::unique_ptr<Homa::InMessage> receive()
-    {
-        return Homa::unique_ptr<Homa::InMessage>(receiver->receiveMessage());
-    }
-
-    virtual void poll();
+    void free() override;
+    Homa::unique_ptr<Socket> open(uint16_t port) override;
+    uint64_t checkTimeouts() override;
+    void processPacket(Driver::Packet* packet, IpAddress source) override;
+    void registerCallbackSendReady(Callback func) override;
+    bool trySend(uint64_t* waitUntil) override;
+    bool trySendGrants() override;
 
     /// See Homa::Transport::getDriver()
     virtual Driver* getDriver()
@@ -73,14 +63,55 @@ class TransportImpl : public Transport {
         return transportId;
     }
 
-  private:
-    void processPackets();
-    void processPacket(Driver::Packet* packet, IpAddress source);
+    /**
+     * Internal implementation of Homa::Socket.
+     *
+     * @sa
+     *      TransportImpl::socketMap
+     */
+    class SocketImpl final : public Socket {
+      public:
+        explicit SocketImpl(TransportImpl* transport, uint16_t port,
+                            Mailbox* mailbox);
+        virtual ~SocketImpl() = default;
 
+        Homa::unique_ptr<Homa::OutMessage> alloc() override;
+        void close() override;
+        Homa::unique_ptr<Homa::InMessage> receive(bool blocking) override;
+        void shutdown() override;
+
+        /// See Homa::Socket::isShutdown()
+        bool isShutdown() const override
+        {
+            return disabled.load(std::memory_order_relaxed);
+        }
+
+        /// See Homa::Socket::getLocalAddress()
+        Address getLocalAddress() const override
+        {
+            return localAddress;
+        }
+
+      private:
+        /// Has the socket been shut down?
+        std::atomic<bool> disabled;
+
+        /// Local address of the socket.
+        Address localAddress;
+
+        /// Mailbox assigned to this socket. Not owned by this class.
+        Mailbox* mailbox;
+
+        /// Transport that owns this socket.
+        TransportImpl* transport;
+    };
+
+  private:
     /// Unique identifier for this transport.
-    const std::atomic<uint64_t> transportId;
+    const uint64_t transportId;
 
     /// Driver from which this transport will send and receive packets.
+    /// Not owned by this class.
     Driver* const driver;
 
     /// Module which manages the network packet priority policy.
@@ -92,11 +123,11 @@ class TransportImpl : public Transport {
     /// Module which receives packets and forms them into messages.
     std::unique_ptr<Core::Receiver> receiver;
 
-    /// Caches the next cycle time that timeouts will need to rechecked.
-    std::atomic<uint64_t> nextTimeoutCycles;
+    /// Module which keeps track of mailboxes currently in use. Not owned by
+    /// this class (we don't even know whether it's instantiated by "new").
+    MailboxDir* const mailboxDir;
 };
 
-}  // namespace Core
-}  // namespace Homa
+}  // namespace Homa::Core
 
 #endif  // HOMA_CORE_TRANSPORT_H

--- a/src/TransportImplTest.cc
+++ b/src/TransportImplTest.cc
@@ -16,6 +16,7 @@
 #include <Homa/Debug.h>
 #include <gtest/gtest.h>
 
+#include "Homa/Utils/TransportPoller.h"
 #include "Mock/MockDriver.h"
 #include "Mock/MockReceiver.h"
 #include "Mock/MockSender.h"
@@ -34,133 +35,156 @@ using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::SetArrayArgument;
 
+/**
+ * Defines a matcher EqPacket(p) to match two Driver::Packet* by their
+ * underlying packet buffer descriptors.
+ */
+MATCHER_P(EqPacket, p, "")
+{
+    return arg->descriptor == p->descriptor;
+}
+
 class TransportImplTest : public ::testing::Test {
   public:
     TransportImplTest()
-        : mockDriver()
-        , transport(new TransportImpl(&mockDriver, 22))
-        , mockSender(
-              new NiceMock<Homa::Mock::MockSender>(22, &mockDriver, 0, 0))
-        , mockReceiver(
-              new NiceMock<Homa::Mock::MockReceiver>(&mockDriver, 0, 0))
+        : mockDriver(allocMockDriver())
+        , mockSender(new NiceMock<Homa::Mock::MockSender>(22, mockDriver, 0, 0))
+        , mockReceiver(new NiceMock<Homa::Mock::MockReceiver>(mockDriver, 0, 0))
+        , transport(new TransportImpl(mockDriver, nullptr, mockSender,
+                                      mockReceiver, 22))
+        , poller(transport)
     {
-        transport->sender.reset(mockSender);
-        transport->receiver.reset(mockReceiver);
-        ON_CALL(mockDriver, getBandwidth).WillByDefault(Return(8000));
-        ON_CALL(mockDriver, getMaxPayloadSize).WillByDefault(Return(1024));
         PerfUtils::Cycles::mockTscValue = 10000;
     }
 
     ~TransportImplTest()
     {
         delete transport;
+        delete mockDriver;
         PerfUtils::Cycles::mockTscValue = 0;
     }
 
-    NiceMock<Homa::Mock::MockDriver> mockDriver;
-    TransportImpl* transport;
+    NiceMock<Homa::Mock::MockDriver>* allocMockDriver()
+    {
+        auto driver = new NiceMock<Homa::Mock::MockDriver>();
+        ON_CALL(*driver, getBandwidth).WillByDefault(Return(8000));
+        ON_CALL(*driver, getMaxPayloadSize).WillByDefault(Return(1024));
+        return driver;
+    }
+
+    NiceMock<Homa::Mock::MockDriver>* mockDriver;
     NiceMock<Homa::Mock::MockSender>* mockSender;
     NiceMock<Homa::Mock::MockReceiver>* mockReceiver;
+    TransportImpl* transport;
+    TransportPoller poller;
 };
 
 TEST_F(TransportImplTest, poll)
 {
-    EXPECT_CALL(mockDriver, receivePackets).WillOnce(Return(0));
-    EXPECT_CALL(*mockSender, poll).Times(1);
-    EXPECT_CALL(*mockReceiver, poll).Times(1);
+    EXPECT_CALL(*mockDriver, receivePackets).WillOnce(Return(0));
+    EXPECT_CALL(*mockSender, trySend).Times(1);
+    EXPECT_CALL(*mockReceiver, trySendGrants).Times(1);
     EXPECT_CALL(*mockSender, checkTimeouts).WillOnce(Return(10000));
     EXPECT_CALL(*mockReceiver, checkTimeouts).WillOnce(Return(10100));
 
-    transport->poll();
+    poller.poll();
 
-    EXPECT_EQ(10000U, transport->nextTimeoutCycles);
+    EXPECT_EQ(10000U, poller.nextTimeoutCycles);
 
-    EXPECT_CALL(mockDriver, receivePackets).WillOnce(Return(0));
-    EXPECT_CALL(*mockSender, poll).Times(1);
-    EXPECT_CALL(*mockReceiver, poll).Times(1);
+    EXPECT_CALL(*mockDriver, receivePackets).WillOnce(Return(0));
+    EXPECT_CALL(*mockSender, trySend).Times(1);
+    EXPECT_CALL(*mockReceiver, trySendGrants).Times(1);
     EXPECT_CALL(*mockSender, checkTimeouts).WillOnce(Return(10200));
     EXPECT_CALL(*mockReceiver, checkTimeouts).WillOnce(Return(10100));
 
-    transport->poll();
+    poller.poll();
 
-    EXPECT_EQ(10100U, transport->nextTimeoutCycles);
+    EXPECT_EQ(10100U, poller.nextTimeoutCycles);
 
-    EXPECT_CALL(mockDriver, receivePackets).WillOnce(Return(0));
-    EXPECT_CALL(*mockSender, poll).Times(1);
-    EXPECT_CALL(*mockReceiver, poll).Times(1);
+    EXPECT_CALL(*mockDriver, receivePackets).WillOnce(Return(0));
+    EXPECT_CALL(*mockSender, trySend).Times(1);
+    EXPECT_CALL(*mockReceiver, trySendGrants).Times(1);
     EXPECT_CALL(*mockSender, checkTimeouts).Times(0);
     EXPECT_CALL(*mockReceiver, checkTimeouts).Times(0);
 
-    transport->poll();
+    poller.poll();
 
-    EXPECT_EQ(10100U, transport->nextTimeoutCycles);
+    EXPECT_EQ(10100U, poller.nextTimeoutCycles);
 }
 
 TEST_F(TransportImplTest, processPackets)
 {
     char payload[8][1024];
-    Homa::Driver::Packet* packets[8];
+    Homa::Driver::Packet packets[8];
 
     // Set DATA packet
-    Homa::Mock::MockDriver::MockPacket dataPacket{payload[0], 1024};
+    Homa::Mock::MockDriver::PacketBuf dataPacketBuf{payload[0]};
+    Driver::Packet dataPacket = dataPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::DataHeader*>(dataPacket.payload)
         ->common.opcode = Protocol::Packet::DATA;
-    packets[0] = &dataPacket;
-    EXPECT_CALL(*mockReceiver, handleDataPacket(Eq(&dataPacket), _));
+    packets[0] = dataPacket;
+    EXPECT_CALL(*mockReceiver, handleDataPacket(EqPacket(&packets[0]), _));
 
     // Set GRANT packet
-    Homa::Mock::MockDriver::MockPacket grantPacket{payload[1], 1024};
+    Homa::Mock::MockDriver::PacketBuf grantPacketBuf{payload[1]};
+    Driver::Packet grantPacket = grantPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::GrantHeader*>(grantPacket.payload)
         ->common.opcode = Protocol::Packet::GRANT;
-    packets[1] = &grantPacket;
-    EXPECT_CALL(*mockSender, handleGrantPacket(Eq(&grantPacket)));
+    packets[1] = grantPacket;
+    EXPECT_CALL(*mockSender, handleGrantPacket(EqPacket(&packets[1])));
 
     // Set DONE packet
-    Homa::Mock::MockDriver::MockPacket donePacket{payload[2], 1024};
+    Homa::Mock::MockDriver::PacketBuf donePacketBuf{payload[2]};
+    Driver::Packet donePacket = donePacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::DoneHeader*>(donePacket.payload)
         ->common.opcode = Protocol::Packet::DONE;
-    packets[2] = &donePacket;
-    EXPECT_CALL(*mockSender, handleDonePacket(Eq(&donePacket)));
+    packets[2] = donePacket;
+    EXPECT_CALL(*mockSender, handleDonePacket(EqPacket(&packets[2])));
 
     // Set RESEND packet
-    Homa::Mock::MockDriver::MockPacket resendPacket{payload[3], 1024};
+    Homa::Mock::MockDriver::PacketBuf resendPacketBuf{payload[3]};
+    Driver::Packet resendPacket = resendPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::ResendHeader*>(resendPacket.payload)
         ->common.opcode = Protocol::Packet::RESEND;
-    packets[3] = &resendPacket;
-    EXPECT_CALL(*mockSender, handleResendPacket(Eq(&resendPacket)));
+    packets[3] = resendPacket;
+    EXPECT_CALL(*mockSender, handleResendPacket(EqPacket(&packets[3])));
 
     // Set BUSY packet
-    Homa::Mock::MockDriver::MockPacket busyPacket{payload[4], 1024};
+    Homa::Mock::MockDriver::PacketBuf busyPacketBuf{payload[4]};
+    Driver::Packet busyPacket = busyPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::PingHeader*>(busyPacket.payload)
         ->common.opcode = Protocol::Packet::BUSY;
-    packets[4] = &busyPacket;
-    EXPECT_CALL(*mockReceiver, handleBusyPacket(Eq(&busyPacket)));
+    packets[4] = busyPacket;
+    EXPECT_CALL(*mockReceiver, handleBusyPacket(EqPacket(&packets[4])));
 
     // Set PING packet
-    Homa::Mock::MockDriver::MockPacket pingPacket{payload[5], 1024};
+    Homa::Mock::MockDriver::PacketBuf pingPacketBuf{payload[5]};
+    Driver::Packet pingPacket = pingPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::PingHeader*>(pingPacket.payload)
         ->common.opcode = Protocol::Packet::PING;
-    packets[5] = &pingPacket;
-    EXPECT_CALL(*mockReceiver, handlePingPacket(Eq(&pingPacket), _));
+    packets[5] = pingPacket;
+    EXPECT_CALL(*mockReceiver, handlePingPacket(EqPacket(&packets[5]), _));
 
     // Set UNKNOWN packet
-    Homa::Mock::MockDriver::MockPacket unknownPacket{payload[6], 1024};
+    Homa::Mock::MockDriver::PacketBuf unknownPacketBuf{payload[6]};
+    Driver::Packet unknownPacket = unknownPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::UnknownHeader*>(unknownPacket.payload)
         ->common.opcode = Protocol::Packet::UNKNOWN;
-    packets[6] = &unknownPacket;
-    EXPECT_CALL(*mockSender, handleUnknownPacket(Eq(&unknownPacket)));
+    packets[6] = unknownPacket;
+    EXPECT_CALL(*mockSender, handleUnknownPacket(EqPacket(&packets[6])));
 
     // Set ERROR packet
-    Homa::Mock::MockDriver::MockPacket errorPacket{payload[7], 1024};
+    Homa::Mock::MockDriver::PacketBuf errorPacketBuf{payload[7]};
+    Driver::Packet errorPacket = errorPacketBuf.toPacket(1024);
     static_cast<Protocol::Packet::ErrorHeader*>(errorPacket.payload)
         ->common.opcode = Protocol::Packet::ERROR;
-    packets[7] = &errorPacket;
-    EXPECT_CALL(*mockSender, handleErrorPacket(Eq(&errorPacket)));
+    packets[7] = errorPacket;
+    EXPECT_CALL(*mockSender, handleErrorPacket(EqPacket(&packets[7])));
 
-    EXPECT_CALL(mockDriver, receivePackets)
+    EXPECT_CALL(*mockDriver, receivePackets)
         .WillOnce(DoAll(SetArrayArgument<1>(packets, packets + 8), Return(8)));
 
-    transport->processPackets();
+    poller.processPackets();
 }
 
 }  // namespace

--- a/src/TransportPoller.cc
+++ b/src/TransportPoller.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2020, Stanford University
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <Cycles.h>
+#include "Homa/Homa.h"
+#include "Homa/Utils/TransportPoller.h"
+#include "Perf.h"
+
+namespace Homa {
+
+/**
+ * Transport poller constructor.
+ *
+ * @param transport
+ *      Transport instance driven by this poller.
+ */
+TransportPoller::TransportPoller(Transport* transport)
+    : transport(transport)
+    , nextTimeoutCycles(0)
+{}
+
+/**
+ * Make incremental progress performing all Transport functionality.
+ *
+ * This method MUST be called for the Transport to make progress and should
+ * be called frequently to ensure timely progress.
+ */
+void
+TransportPoller::poll()
+{
+    // Receive and dispatch incoming packets.
+    processPackets();
+
+    // Allow sender and receiver to make incremental progress.
+    uint64_t waitUntil;
+    transport->trySend(&waitUntil);
+    transport->trySendGrants();
+
+    if (PerfUtils::Cycles::rdtsc() >= nextTimeoutCycles.load()) {
+        uint64_t requestedTimeoutCycles = transport->checkTimeouts();
+        nextTimeoutCycles.store(requestedTimeoutCycles);
+    }
+}
+
+/**
+ * Helper method which receives a burst of incoming packets and process them
+ * through the transport protocol.  Pulled out of TransportPoller::poll() to
+ * simplify unit testing.
+ */
+void
+TransportPoller::processPackets()
+{
+    // Keep track of time spent doing active processing versus idle.
+    uint64_t cycles = PerfUtils::Cycles::rdtsc();
+
+    const int MAX_BURST = 32;
+    Driver::Packet packets[MAX_BURST];
+    IpAddress srcAddrs[MAX_BURST];
+    Driver* driver = transport->getDriver();
+    int numPackets = driver->receivePackets(MAX_BURST, packets, srcAddrs);
+    for (int i = 0; i < numPackets; ++i) {
+        transport->processPacket(&packets[i], srcAddrs[i]);
+    }
+
+    cycles = PerfUtils::Cycles::rdtsc() - cycles;
+    if (numPackets > 0) {
+        Perf::counters.active_cycles.add(cycles);
+    } else {
+        Perf::counters.idle_cycles.add(cycles);
+    }
+}
+
+}  // namespace Homa

--- a/test/dpdk_test.cc
+++ b/test/dpdk_test.cc
@@ -55,15 +55,15 @@ main(int argc, char* argv[])
         std::cout << Homa::IpAddress::toString(driver.getLocalAddress())
                   << std::endl;
         while (true) {
-            Homa::Driver::Packet* incoming[10];
+            Homa::Driver::Packet incoming[10];
             Homa::IpAddress srcAddrs[10];
             uint32_t receivedPackets;
             do {
                 receivedPackets = driver.receivePackets(10, incoming, srcAddrs);
             } while (receivedPackets == 0);
-            Homa::Driver::Packet* pong = driver.allocPacket();
-            pong->length = 100;
-            driver.sendPacket(pong, srcAddrs[0], 0);
+            Homa::Driver::Packet pong = driver.allocPacket();
+            pong.length = 100;
+            driver.sendPacket(&pong, srcAddrs[0], 0);
             driver.releasePackets(incoming, receivedPackets);
             driver.releasePackets(&pong, 1);
         }
@@ -74,15 +74,15 @@ main(int argc, char* argv[])
         for (int i = 0; i < 100000; ++i) {
             uint64_t start = PerfUtils::Cycles::rdtsc();
             PerfUtils::TimeTrace::record(start, "START");
-            Homa::Driver::Packet* ping = driver.allocPacket();
+            Homa::Driver::Packet ping = driver.allocPacket();
             PerfUtils::TimeTrace::record("allocPacket");
-            ping->length = 100;
+            ping.length = 100;
             PerfUtils::TimeTrace::record("set ping args");
-            driver.sendPacket(ping, server_ip, 0);
+            driver.sendPacket(&ping, server_ip, 0);
             PerfUtils::TimeTrace::record("sendPacket");
             driver.releasePackets(&ping, 1);
             PerfUtils::TimeTrace::record("releasePacket");
-            Homa::Driver::Packet* incoming[10];
+            Homa::Driver::Packet incoming[10];
             Homa::IpAddress srcAddrs[10];
             uint32_t receivedPackets;
             do {

--- a/test/system_test.cc
+++ b/test/system_test.cc
@@ -16,11 +16,11 @@
 #include <Homa/Debug.h>
 #include <Homa/Drivers/Fake/FakeDriver.h>
 #include <Homa/Homa.h>
-#include <unistd.h>
+#include <Homa/Utils/SimpleMailboxDir.h>
+#include <Homa/Utils/TransportPoller.h>
 
 #include <atomic>
 #include <iostream>
-#include <memory>
 #include <random>
 #include <string>
 #include <thread>
@@ -47,6 +47,7 @@ static const char USAGE[] = R"(Homa System Test.
 
 bool _PRINT_CLIENT_ = false;
 bool _PRINT_SERVER_ = false;
+static const uint16_t SERVER_PORT = 60001;
 
 struct MessageHeader {
     uint64_t id;
@@ -57,28 +58,33 @@ struct Node {
     explicit Node(uint64_t id)
         : id(id)
         , driver()
-        , transport(Homa::Transport::create(&driver, id))
+        , mailboxDir()
+        , transport(Homa::Transport::create(&driver, &mailboxDir, id))
         , thread()
         , run(false)
+        , serverSocket(transport->open(SERVER_PORT))
     {}
 
     const uint64_t id;
     Homa::Drivers::Fake::FakeDriver driver;
-    Homa::Transport* transport;
+    Homa::SimpleMailboxDir mailboxDir;
+    Homa::unique_ptr<Homa::Transport> transport;
     std::thread thread;
     std::atomic<bool> run;
+    Homa::unique_ptr<Homa::Socket> serverSocket;
 };
 
 void
 serverMain(Node* server, std::vector<Homa::IpAddress> addresses)
 {
+    Homa::TransportPoller poller(server->transport.get());
     while (true) {
         if (server->run.load() == false) {
             break;
         }
 
         Homa::unique_ptr<Homa::InMessage> message =
-            server->transport->receive();
+            server->serverSocket->receive(false);
 
         if (message) {
             MessageHeader header;
@@ -92,7 +98,7 @@ serverMain(Node* server, std::vector<Homa::IpAddress> addresses)
             }
             message->acknowledge();
         }
-        server->transport->poll();
+        poller.poll();
     }
 }
 
@@ -112,16 +118,18 @@ clientMain(int count, int size, std::vector<Homa::IpAddress> addresses)
     int numFailed = 0;
 
     Node client(1);
+    Homa::TransportPoller poller(client.transport.get());
+    Homa::unique_ptr<Homa::Socket> clientSocket = client.transport->open(0);
     for (int i = 0; i < count; ++i) {
         uint64_t id = nextId++;
         char payload[size];
-        for (int i = 0; i < size; ++i) {
-            payload[i] = randData(gen);
+        for (char& byte : payload) {
+            byte = randData(gen);
         }
 
         Homa::IpAddress destAddress = addresses[randAddr(gen)];
 
-        Homa::unique_ptr<Homa::OutMessage> message = client.transport->alloc(0);
+        Homa::unique_ptr<Homa::OutMessage> message = clientSocket->alloc();
         {
             MessageHeader header;
             header.id = id;
@@ -133,7 +141,7 @@ clientMain(int count, int size, std::vector<Homa::IpAddress> addresses)
                           << std::endl;
             }
         }
-        message->send(Homa::SocketAddress{destAddress, 60001});
+        message->send(Homa::SocketAddress{destAddress, SERVER_PORT});
 
         while (1) {
             Homa::OutMessage::Status status = message->getStatus();
@@ -143,7 +151,7 @@ clientMain(int count, int size, std::vector<Homa::IpAddress> addresses)
                 numFailed++;
                 break;
             }
-            client.transport->poll();
+            poller.poll();
         }
     }
     return numFailed;
@@ -193,16 +201,14 @@ main(int argc, char* argv[])
         servers.push_back(server);
     }
 
-    for (auto it = servers.begin(); it != servers.end(); ++it) {
-        Node* server = *it;
+    for (auto server : servers) {
         server->run = true;
         server->thread = std::move(std::thread(&serverMain, server, addresses));
     }
 
     int numFails = clientMain(numTests, numBytes, addresses);
 
-    for (auto it = servers.begin(); it != servers.end(); ++it) {
-        Node* server = *it;
+    for (auto server : servers) {
         server->run = false;
         server->thread.join();
         delete server;


### PR DESCRIPTION
The biggest challenge is to move away from the poll-based execution model
previously embedded in the implementation. For example, Shenango can't
afford to drive the execution of the transport by calling Transport::poll
in a busy loop. Also, Shenango needs to allow users to block on a socket
waiting for incoming messages.

Another refactoring that results in small code changes all over the place
is the Driver::Packet interface. The old interface cannot prevent the
driver from modifying the payload (e.g., prepend L3 headers). This will
lead to corrupted message when the packet needs to be retransmitted.

List of major changes:
- CHoma: provide C-bindings of the Homa APIs (Shenango is written in C)
- Shenango: implement Shenango Driver, MailboxDir, and Mailbox
- TransportPoller: extract poll-based execution model out of the Transport
- SimpleMailboxDir: a simple reference implementation for Homa::MailboxDir
- Driver::Packet: a new packet interface to eliminate the awkward PacketSpec;
  this is used to provide an immutable view of the packet to the transport
  (driver can prepend headers to the payload w/o affecting the transport)
- Sender: add a couple of user-defined callbacks (Shenango currently relies
  on them to wake up blocking threads)
- Finally, bring unit tests up-to-date.