### PR TITLE
[Draf] Simplify core

### DIFF
--- a/include/Homa/Homa.h
+++ b/include/Homa/Homa.h
@@ -71,17 +71,6 @@ class InMessage {
     virtual void acknowledge() const = 0;
 
     /**
-     * Returns true if the sender is no longer waiting for this message to be
-     * processed; false otherwise.
-     */
-    virtual bool dropped() const = 0;
-
-    /**
-     * Inform the sender that this message has failed to be processed.
-     */
-    virtual void fail() const = 0;
-
-    /**
      * Get the contents of a specified range of bytes in the Message by
      * copying them into the provided destination memory region.
      *

--- a/include/Homa/Util.h
+++ b/include/Homa/Util.h
@@ -74,13 +74,14 @@ isPowerOfTwo(num_type n)
  * Round up the result of x divided by y, where both x and y are positive
  * integers.
  */
-template <typename num_type>
+template <typename num_type, typename Y>
 constexpr num_type
-roundUpIntDiv(num_type x, num_type y)
+roundUpIntDiv(num_type x, Y y)
 {
     static_assert(std::is_integral<num_type>::value, "Integral required.");
     assert(x > 0 && y > 0);
-    return (x + y - 1) / y;
+    num_type yy = downCast<num_type>(y);
+    return (x + yy - 1) / yy;
 }
 
 /**

--- a/include/Homa/Util.h
+++ b/include/Homa/Util.h
@@ -71,6 +71,19 @@ isPowerOfTwo(num_type n)
 }
 
 /**
+ * Round up the result of x divided by y, where both x and y are positive
+ * integers.
+ */
+template <typename num_type>
+constexpr num_type
+roundUpIntDiv(num_type x, num_type y)
+{
+    static_assert(std::is_integral<num_type>::value, "Integral required.");
+    assert(x > 0 && y > 0);
+    return (x + y - 1) / y;
+}
+
+/**
  * This class is used to temporarily release lock in a safe fashion. Creating
  * an object of this class will unlock its associated mutex; when the object
  * is deleted, the mutex will be locked again. The template class T must be

--- a/src/Drivers/DPDK/DpdkDriverImpl.h
+++ b/src/Drivers/DPDK/DpdkDriverImpl.h
@@ -184,9 +184,6 @@ class DpdkDriver::Impl {
     /// set by override).
     const int HIGHEST_PACKET_PRIORITY;
 
-    /// Protects access to the packetPool.
-    SpinLock packetLock;
-
     /// Provides memory allocation for the DPDK specific implementation of a
     /// Driver Packet.
     ObjectPool<Packet> packetPool;

--- a/src/Intrusive.h
+++ b/src/Intrusive.h
@@ -486,26 +486,25 @@ class List {
  * @tparam ElementType
  *      Type of the element held in the Intrusive::List.
  * @tparam Compare
- *      A weak strict ordering binary comparator for objects of ElementType.
+ *      A weak strict ordering binary comparator for objects of ElementType
+ *      which returns true when the first argument should be ordered before
+ *      the second. The signature should be equivalent to the following:
+ *          bool comp(const ElementType& a, const ElementType& b);
  * @param list
  *      List that contains the element.
  * @parma node
  *      Intrusive list node for the element that should be prioritized.
- * @param comp
- *      Comparison function object which returns true when the first argument
- *      should be ordered before the second.  The signature should be equivalent
- *      to the following:
- *          bool comp(const ElementType& a, const ElementType& b);
  */
-template <typename ElementType, typename Compare>
+template <typename ElementType,
+          typename Compare = typename ElementType::ComparePriority>
 void
-prioritize(List<ElementType>* list, typename List<ElementType>::Node* node,
-           Compare comp)
+prioritize(List<ElementType>* list, typename List<ElementType>::Node* node)
 {
     assert(list->contains(node));
     auto it_node = list->get(node);
     auto it_pos = it_node;
     while (it_pos != list->begin()) {
+        Compare comp;
         if (!comp(*it_node, *std::prev(it_pos))) {
             // Found the correct location; just before it_pos.
             break;
@@ -528,25 +527,24 @@ prioritize(List<ElementType>* list, typename List<ElementType>::Node* node,
  * @tparam ElementType
  *      Type of the element held in the Intrusive::List.
  * @tparam Compare
- *      A weak strict ordering binary comparator for objects of ElementType.
+ *      A weak strict ordering binary comparator for objects of ElementType
+ *      which returns true when the first argument should be ordered before
+ *      the second. The signature should be equivalent to the following:
+ *          bool comp(const ElementType& a, const ElementType& b);
  * @param list
  *      List that contains the element.
  * @parma node
  *      Intrusive list node for the element that should be prioritized.
- * @param comp
- *      Comparison function object which returns true when the first argument
- *      should be ordered before the second.  The signature should be equivalent
- *      to the following:
- *          bool comp(const ElementType& a, const ElementType& b);
  */
-template <typename ElementType, typename Compare>
+template <typename ElementType,
+          typename Compare = typename ElementType::ComparePriority>
 void
-deprioritize(List<ElementType>* list, typename List<ElementType>::Node* node,
-             Compare comp)
+deprioritize(List<ElementType>* list, typename List<ElementType>::Node* node)
 {
     assert(list->contains(node));
     auto it_node = list->get(node);
     auto it_pos = std::next(it_node);
+    Compare comp;
     while (it_pos != list->end()) {
         if (comp(*it_node, *it_pos)) {
             // Found the correct location; just before it_pos.

--- a/src/Receiver.cc
+++ b/src/Receiver.cc
@@ -84,8 +84,12 @@ Receiver::~Receiver()
  *      The incoming packet to be processed.
  * @param sourceIp
  *      Source IP address of the packet.
+ * @return
+ *      True if the Receiver decides to take ownership of the packet. False
+ *      if the Receiver has no more use of this packet and it can be released
+ *      to the driver.
  */
-void
+bool
 Receiver::handleDataPacket(Driver::Packet* packet, IpAddress sourceIp)
 {
     Protocol::Packet::DataHeader* header =
@@ -164,9 +168,9 @@ Receiver::handleDataPacket(Driver::Packet* packet, IpAddress sourceIp)
         }
     } else {
         // must be a duplicate packet; drop packet.
-        driver->releasePackets(&packet, 1);
+        return false;
     }
-    return;
+    return true;
 }
 
 /**
@@ -193,7 +197,6 @@ Receiver::handleBusyPacket(Driver::Packet* packet)
             bucket->resendTimeouts.setTimeout(&message->resendTimeout);
         }
     }
-    driver->releasePackets(&packet, 1);
 }
 
 /**
@@ -247,7 +250,6 @@ Receiver::handlePingPacket(Driver::Packet* packet, IpAddress sourceIp)
         ControlPacket::send<Protocol::Packet::UnknownHeader>(driver, sourceIp,
                                                              id);
     }
-    driver->releasePackets(&packet, 1);
 }
 
 /**

--- a/src/Receiver.h
+++ b/src/Receiver.h
@@ -48,7 +48,7 @@ class Receiver {
                       uint64_t messageTimeoutCycles,
                       uint64_t resendIntervalCycles);
     virtual ~Receiver();
-    virtual void handleDataPacket(Driver::Packet* packet, IpAddress sourceIp);
+    virtual bool handleDataPacket(Driver::Packet* packet, IpAddress sourceIp);
     virtual void handleBusyPacket(Driver::Packet* packet);
     virtual void handlePingPacket(Driver::Packet* packet, IpAddress sourceIp);
     virtual Homa::InMessage* receiveMessage();

--- a/src/Sender.cc
+++ b/src/Sender.cc
@@ -527,7 +527,7 @@ Sender::checkTimeouts()
 {
     uint index = nextBucketIndex.fetch_add(1, std::memory_order_relaxed) &
                  MessageBucketMap::HASH_KEY_MASK;
-    MessageBucket* bucket = messageBuckets.buckets.at(index);
+    MessageBucket* bucket = &messageBuckets.buckets[index];
     uint64_t now = PerfUtils::Cycles::rdtsc();
     checkPingTimeouts(now, bucket);
     checkMessageTimeouts(now, bucket);

--- a/src/Sender.h
+++ b/src/Sender.h
@@ -119,9 +119,6 @@ class Sender {
 
     /**
      * Represents an outgoing message that can be sent.
-     *
-     * TODO: document which part of the Message state are immutable, which part
-     * is thread-safe, and which part should be protected by mutex.
      */
     class Message : public Homa::OutMessage {
       public:
@@ -148,7 +145,7 @@ class Sender {
             // construction. See Message::occupied.
             , state(Status::NOT_STARTED)
             , bucketNode(this)
-            , messageTimeout(this)
+            , numPingTimeouts(0)
             , pingTimeout(this)
             , queuedMessageInfo(this)
         {}
@@ -156,7 +153,6 @@ class Sender {
         virtual ~Message();
         void append(const void* source, size_t count) override;
         void cancel() override;
-        void destroy();
         Status getStatus() const override;
         void setStatus(Status newStatus, bool deschedule);
         size_t length() const override;
@@ -239,10 +235,9 @@ class Sender {
         /// is protected by the associated MessageBucket::mutex;
         Intrusive::List<Message>::Node bucketNode;
 
-        /// Intrusive structure used by the Sender to keep track when the
-        /// sending of this message should be considered failed.  Access to this
+        /// Number of ping timeouts that occurred in a row.  Access to this
         /// structure is protected by the associated MessageBucket::mutex.
-        Timeout<Message> messageTimeout;
+        int numPingTimeouts;
 
         /// Intrusive structure used by the Sender to keep track when this
         /// message should be checked to ensure progress is still being made.
@@ -268,18 +263,13 @@ class Sender {
         /**
          * MessageBucket constructor.
          *
-         * @param messageTimeoutCycles
-         *      Number of cycles of inactivity to wait before a Message is
-         *      considered failed.
          * @param pingIntervalCycles
          *      Number of cycles of inactivity to wait between checking on the
          *      liveness of a Message.
          */
-        explicit MessageBucket(uint64_t messageTimeoutCycles,
-                               uint64_t pingIntervalCycles)
+        explicit MessageBucket(uint64_t pingIntervalCycles)
             : mutex()
             , messages()
-            , messageTimeouts(messageTimeoutCycles)
             , pingTimeouts(pingIntervalCycles)
         {}
 
@@ -312,11 +302,6 @@ class Sender {
         /// Collection of outbound messages
         Intrusive::List<Message> messages;
 
-        // FIXME: we should be able eliminate this field if messageTimeout is
-        // always a multiple of pingTimeout
-        /// Maintains Message objects in increasing order of timeout.
-        TimeoutManager<Message> messageTimeouts;
-
         /// Maintains Message objects in increasing order of ping timeout.
         TimeoutManager<Message> pingTimeouts;
     };
@@ -346,21 +331,17 @@ class Sender {
         /**
          * MessageBucketMap constructor.
          *
-         * @param messageTimeoutCycles
-         *      Number of cycles of inactivity to wait before a Message is
-         *      considered failed.
          * @param pingIntervalCycles
          *      Number of cycles of inactivity to wait between checking on the
          *      liveness of a Message.
          */
-        explicit MessageBucketMap(uint64_t messageTimeoutCycles,
-                                  uint64_t pingIntervalCycles)
+        explicit MessageBucketMap(uint64_t pingIntervalCycles)
             : buckets()
             , hasher()
         {
             buckets.reserve(NUM_BUCKETS);
             for (int i = 0; i < NUM_BUCKETS; ++i) {
-                buckets.emplace_back(messageTimeoutCycles, pingIntervalCycles);
+                buckets.emplace_back(pingIntervalCycles);
             }
         }
 
@@ -388,8 +369,6 @@ class Sender {
     };
 
     void startMessage(Sender::Message* message, bool restart);
-    // FIXME: merge the following two methods
-    static void checkMessageTimeouts(uint64_t now, MessageBucket* bucket);
     void checkPingTimeouts(uint64_t now, MessageBucket* bucket);
     void trySend();
 
@@ -409,13 +388,14 @@ class Sender {
     /// The maximum number of bytes that should be queued in the Driver.
     const uint32_t DRIVER_QUEUED_BYTE_LIMIT;
 
+    /// The number of ping timeouts to occur before declaring a message timeout.
+    const int MESSAGE_TIMEOUT_INTERVALS;
+
     /// Tracks all outbound messages being sent by the Sender.
     MessageBucketMap messageBuckets;
 
-    // TODO: document the locking principle that if someone want to acquire both
-    // a bucket mutex and this queueMutex, the bucket mutex must be acquired first!
-    // TODO: why this principle? why not the reverse order?
-    /// Protects the sendQueue.
+    /// Protects the sendQueue.  Locking principle: when a bucket mutex is also
+    /// required, it must be acquired before the sendQueue mutex.
     SpinLock queueMutex;
 
     /// A list of outbound messages that have unsent packets.  Messages are kept
@@ -438,12 +418,7 @@ class Sender {
     std::atomic<uint> nextBucketIndex;
 
     /// Used to allocate Message objects.
-    struct {
-        /// Protects the messageAllocator.pool
-        SpinLock mutex;
-        /// Pool allocator for Message objects.
-        ObjectPool<Message> pool;
-    } messageAllocator;
+    ObjectPool<Message> messageAllocator;
 };
 
 }  // namespace Core

--- a/src/SenderTest.cc
+++ b/src/SenderTest.cc
@@ -1575,7 +1575,6 @@ TEST_F(SenderTest, cancelMessage)
     EXPECT_TRUE(bucket->pingTimeouts.list.empty());
     EXPECT_TRUE(sender->sendQueue.empty());
     EXPECT_EQ(Homa::OutMessage::Status::CANCELED, message->state.load());
-    // FIXME: shouldn't we check if the bucket is empty?
 }
 
 TEST_F(SenderTest, dropMessage_basic)

--- a/src/SenderTest.cc
+++ b/src/SenderTest.cc
@@ -1575,6 +1575,7 @@ TEST_F(SenderTest, cancelMessage)
     EXPECT_TRUE(bucket->pingTimeouts.list.empty());
     EXPECT_TRUE(sender->sendQueue.empty());
     EXPECT_EQ(Homa::OutMessage::Status::CANCELED, message->state.load());
+    // FIXME: shouldn't we check if the bucket is empty?
 }
 
 TEST_F(SenderTest, dropMessage_basic)

--- a/src/Timeout.h
+++ b/src/Timeout.h
@@ -100,12 +100,16 @@ class TimeoutManager {
      *
      * @param timeout
      *      The Timeout that should be scheduled.
+     * @param now
+     *      Optionally provided "current" timestamp cycle time. Used to avoid
+     *      unnecessary calls to PerfUtils::Cycles::rdtsc() if the current time
+     *      is already available to the caller.
      */
-    inline void setTimeout(Timeout<ElementType>* timeout)
+    inline void setTimeout(Timeout<ElementType>* timeout,
+                           uint64_t now = PerfUtils::Cycles::rdtsc())
     {
         list.remove(&timeout->node);
-        timeout->expirationCycleTime =
-            PerfUtils::Cycles::rdtsc() + timeoutIntervalCycles;
+        timeout->expirationCycleTime = now + timeoutIntervalCycles;
         list.push_back(&timeout->node);
         nextTimeout.store(list.front().expirationCycleTime,
                           std::memory_order_relaxed);

--- a/src/TransportImpl.cc
+++ b/src/TransportImpl.cc
@@ -14,11 +14,7 @@
  */
 
 #include "TransportImpl.h"
-
 #include <algorithm>
-#include <memory>
-#include <utility>
-
 #include "Cycles.h"
 #include "Perf.h"
 #include "Protocol.h"

--- a/src/TransportImpl.cc
+++ b/src/TransportImpl.cc
@@ -135,6 +135,7 @@ TransportImpl::processPacket(Driver::Packet* packet, IpAddress sourceIp)
             sender->handleGrantPacket(packet);
             break;
         case Protocol::Packet::DONE:
+            // fixme: rename DONE to ACK?
             Perf::counters.rx_done_pkts.add(1);
             sender->handleDonePacket(packet);
             break;
@@ -155,6 +156,7 @@ TransportImpl::processPacket(Driver::Packet* packet, IpAddress sourceIp)
             sender->handleUnknownPacket(packet);
             break;
         case Protocol::Packet::ERROR:
+            // FIXME: remove ERROR?
             Perf::counters.rx_error_pkts.add(1);
             sender->handleErrorPacket(packet);
             break;

--- a/src/TransportImpl.h
+++ b/src/TransportImpl.h
@@ -75,7 +75,7 @@ class TransportImpl : public Transport {
 
   private:
     void processPackets();
-    void processPacket(Driver::Packet* packet, IpAddress source);
+    bool processPacket(Driver::Packet* packet, IpAddress source);
 
     /// Unique identifier for this transport.
     const std::atomic<uint64_t> transportId;


### PR DESCRIPTION
List of major changes:

- Make `ObjectPool` thread-safe so we don't need to hold the lock during object construction/destruction
- Simplify the interface of `Intrusive:[de]prioritize`
- Let `TransportImpl::processProcket` return a boolean to indicate whether the packet is retained by the transport (remove most `driver->release` in `Sender|Receiver`
- Eliminate `Message::messageTimeout` in both `Sender` and `Receiver`
- Extract a common `handleIncomingPacket` method to execute common logic shared in `handleXXXPacket`
- Clean up destructors in both `Sender` and `Receiver`
- `Sender.h`: perform `cancelTimeout` in the new `Message::setStatus` method
- `Sender.cc`: eliminate a lot of duplicate code that removes messages from the send queue by moving the code into `Message::setStatus`
- `Sender.cc`: eliminate duplicate code shared by `handleUnknownPacket` and `Sender::sendMessage` by extracting a `startMessage` method

